### PR TITLE
Correct build for Windows when MSVCRT is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ After installing/compiling wxWidgets, ensure that wx-config is in your path, cd 
 
 (Don't use sudo on Cygwin, instead type in `./build.sh install` and you'll be prompted whether you wish to launch the command in an Administration MinTTY session, then the build will run from a second terminal window that runs within the Administrator context.)
 
-This will install the lisaem and lisafsh-tool binaries to /usr/local/bin, and will install skins and sound files to /usr/local/share/LisaEm/; on Windows it will be installed to C:\Program Files\Sunder.Net\LisaEm and /Applications for macOS.
+This will install the lisaem and lisafsh-tool binaries to /usr/local/bin, and will install skins and sound files to /usr/local/share/LisaEm/; on Windows it will be installed to C:\Program Files\Sunder.Net\LisaEm (you may need to have launched Cygwin as admin to write to Program Files) and /Applications for macOS.
 
 ![compiling lisaem](resources/2-build-lisaem.gif)
 

--- a/src/lisa/io_board/z8530.c
+++ b/src/lisa/io_board/z8530.c
@@ -255,6 +255,8 @@ extern void set_port_baud_tty(int port, uint32 baud);
 #else
 // temp disable for windows until we flesh these guys out
 char read_serial_port_pty(unsigned int port) { return 0; }
+extern char read_serial_port_tty(unsigned int port);
+void write_serial_port_pty(unsigned int port, char c) {}
 int poll_telnet_serial_read(int portnum) { return 0; }
 #endif
 


### PR DESCRIPTION
With this fix, the build works with __MSVCRT__ defined under Cygwin on Windows 11 23H2