### PR TITLE
Fix incorrect check when attempting to boot from existing disk.

### DIFF
--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -10079,7 +10079,7 @@ extern "C" int pickprofilesize(char *filename, int allowexisting)
 
           check = dc42_auto_open(&P, filename, "");
           // if we failed to open, or it's not at least a 5MB dc42 image, alert and don't accept
-          if ((!check) || P.datasizetotal < (9728 * 512))
+          if ((check) || P.datasizetotal < (9728 * 512))
           {
             filename[0] = 0; // clear return file
             messagebox("The selected file is either not a proper DC42 image, or it's not a ProFile/Widget image.", "Sorry Not a Lisa Hard Disk Image");


### PR DESCRIPTION
**TL;DR** This pull request fixes a problem where LisaEm will refuse to boot from an existing, valid DC42 ProFile disk chosen by the user at start up.

## The Details

When LisaEm is powered on without an existing disk, one of the options presented is **Select existing ProFile instead of creating a new.**

<p align="center">
<img width="477" alt="LisaEmHardDriveSizeDialog" src="https://github.com/user-attachments/assets/ed053e94-cd64-4d52-9a20-62e56528db40">
</p>

If this option is chosen and a valid ProFile DC42 image is chosen, LisaEm will complain. 

<p align="center">
<img width="274" alt="SorryNotALisaHardDiskImage" src="https://github.com/user-attachments/assets/3320c35f-d28f-4651-9ac3-0721335fde1b">
</p>

This is caused by the following piece of code in [lisaem_wx.cpp](https://github.com/arcanebyte/lisaem/blob/6660f7b7eaea09f6b2c648cdd2a9bfa70dc7a8a3/src/host/wxui/lisaem_wx.cpp#L10080-L10088):
```c
check = dc42_auto_open(&P, filename, "");
// if we failed to open, or it's not at least a 5MB dc42 image, alert and don't accept
if ((!check) || P.datasizetotal < (9728 * 512))                                  {
    filename[0] = 0; // clear return file
    messagebox("The selected file is either not a proper DC42 image, or it's not a ProFile/Widget image.", "Sorry Not a Lisa Hard Disk Image");                   }
```
The problem is that `dc42_auto_open` returns `0` on success, so the correct error check is `check` not `!check`.

Deleting this one `!` character allows the hard disk to open without issues.