### PR TITLE
Fixing a bug I introduced in my recent commit for support of Twiggy floppy disks

### DIFF
--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -262,7 +262,6 @@ extern "C" void iw_enddocuments(void);
 // defined in in floppy.c:
 extern uint32 total_num_sectors_read;
 extern uint32 total_num_sectors_written; 
-extern uint8 emulated_drive_number;
 
 void iw_check_finish_job(void);
 
@@ -1800,7 +1799,7 @@ void LisaEmFrame::Update_Status(long elapsed,long idleentry)
       s = "MHz";
     }
 
-    text.Printf(_T("CPU: %1.2f%s want:%1.2fMHz tick:%d, video refresh:%1.2f%s %c contrast:%02x %s %x%x:%x%x:%x%x.%x @%d/%08x clk_cycles:%lld %sSectors_R/W:%d/%d"),
+    text.Printf(_T("CPU: %1.2f%s want:%1.2fMHz tick:%d, video refresh:%1.2f%s %c contrast:%02x %s %x%x:%x%x:%x%x.%x @%d/%08x clk_cycles:%lld FloppySectors_R/W:%d/%d"),
                 mhzactual, c, throttle, emulation_tick,
                 vidhz, s, (videoramdirty ? 'd' : ' '),
                 contrast,
@@ -1810,7 +1809,6 @@ void LisaEmFrame::Update_Status(long elapsed,long idleentry)
                 lisa_clock.secs_h, lisa_clock.secs_l,
                 lisa_clock.tenths,
                 context, pc24, cpu68k_clocks,
-                (emulated_drive_number==0x00)? "TwiggyFloppy":"SonyFloppy",
                 total_num_sectors_read, total_num_sectors_written);
 
     SetStatusBarText(text);


### PR DESCRIPTION

Fixing a bug I introduced in my recent commit for support of Twiggy floppy disks.

The bug was:
In LOS3,  upon inserting a sony floppy disk image, sometimes, randomly, Lisa pops up an error window saying that it is experiencing technical difficulties, and needs to restart. The bug manifested also in another way: when installing software from floppies onto the ProFile, sometimes, randomly the installation will error out with error "10291" and it returns to the boot screen.

This time I tested the heck out of it and am confident that it works great.

Also, I made a good cleanup in the existing code: there were comments like "this is wrong", "this is also wrong", etc. I figured these out. I am becoming confident in "taking over" this code.

Note about the Twiggy support: as I stated in my earlier commit, booting from twiggy disk image files works great now. However, the code supports only one  floppy drive (the upper drive number 1). This prevents us from e.g. completing installation of LOS1.0, because it asks to insert floppy disk 2 into the lower drive 2, which is unsupported. I am working on supporting both drives, and will submit another pull request in a few days. 

Cheers!



