### PR TITLE
Added support for both Twiggy floppy drives in Lisa 1 mode.

### DIFF
--- a/HowToBuildOnWindows.md
+++ b/HowToBuildOnWindows.md
@@ -43,24 +43,24 @@ cd ~
 git clone https://github.com/arcanebyte/lisaem.git
 ```
 
-This will download the latest LisaEm sources into new subfolder `LisaEm`.
+This will download the latest LisaEm sources into new subfolder `lisaem`.
 
 ## 4. Download and build the wxWidgets binaries
 Run the following commands in Cygwin:
 
 ```
-cd ~/LisaEm/scripts
-./build-wx3.1.5-cygwin-windows.sh
+cd ~/lisaem/scripts
+./build-wx3.2.7-cygwin-windows.sh
 ```
 
-This will download file `wxWidgets-3.1.5.tar.bz2` , expand it into subfolder `wxWidgets-3.1.5`, build it in subfolder `wxWidgets-3.1.5/build-msw`, install wxWidgets into folder `/usr/local/wx3.1.5-msw` and delete the temporary build folder above. Upon success, it should print e.g. `Default config is msw-unicode-static-3.1`.
+This will download file `wxWidgets-3.2.7.tar.bz2` from https://github.com/wxwidgets/wxwidgets/releases , expand it into subfolder `wxWidgets-3.2.7`, build it in subfolder `wxWidgets-3.2.7/build-msw`, install wxWidgets into folder `/usr/local/wx3.2.7-msw` and delete the temporary build folder above. Upon success, it should print e.g. `Default config is msw-unicode-static-3.1`.
 
 ## 5. Build the LisaEm binaries
 Run the following commands in Cygwin:
 
 ```
-cd ~/LisaEm
-./build.sh build
+cd ~/lisaem
+./build.sh clean build
 ```
 
 This will compile and generate the LisaEm executable file `bin/lisaem.exe`, along with other tools in the same `bin` subfolder.
@@ -71,10 +71,10 @@ This will compile and generate the LisaEm executable file `bin/lisaem.exe`, alon
   The LisaEm build system comes with the "build install" command, which creates folder `C:\Program Files\Sunder.NET\LisaEm` and copies the necessary LisaEm files into it. It does not do anything else than that (does not create any other files, does not create desktop or startup menu shortcuts, does not modify the Windows registry). Run the following commands in Cygwin:
   
   ```
-  cd ~/LisaEm
+  cd ~/lisaem
   ./build.sh install
   ```
-  
+
   Follow the prompts. It will launch a separate "mintty.exe" command window "As Administrator", so that it would be able to write into folder C:\Program Files\Sunder.NET\LisaEm.
 
   ### Option 2: Install it manually, by running a set of commands in Cygwin
@@ -91,10 +91,12 @@ This will compile and generate the LisaEm executable file `bin/lisaem.exe`, alon
   ```
 
 ## Running the LisaEm emulator
-Open Windows File Explorer and navigate to your installation folder (e.g. `C:\Program Files\Sunder.NET\LisaEm`) and double-click on LisaEm.exe to launch it.
+You don't need Cygwin in order to run LisaEm. Open Windows File Explorer, navigate to your installation folder (e.g. `C:\Program Files\Sunder.NET\LisaEm`) and double-click on LisaEm.exe to launch it.
 
 At first start, it will create the emulator "preferences" file `C:\Users\<Your Windows User>\AppData\Roaming\lisaem.conf`.
 This way, regardless of how / from where you've started the emulator, it will always find this config file.
+
+Does the Lisa feel sluggish? No problem! Go to the "Throttle" menu, and choose how fast do you want it to be, e.g. change it from the default 5 Mhz to 256 Mhz. Restart.
 
 ## Uninstalling LisaEm
 To reduce the risk of deleting "too much" by mistake, we have not implemented a "build uninstall" command.

--- a/scripts/build-wx3.2.7-cygwin-windows.sh
+++ b/scripts/build-wx3.2.7-cygwin-windows.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This script downloads the wxWidgets-3.1.5.tar.bz2 source archive file from
-# https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2
-# , extracts it into subfolder "wxWidgets-3.1.5",
-# then builds wxWidgets into subfolder "wxWidgets-3.1.5/build-msw",
-# and finally installs wxWidgets into folder "/usr/local/wx3.1.5-msw",
+# This script downloads the wxWidgets-3.2.7.tar.bz2 source archive file from
+# https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.7/wxWidgets-3.2.7.tar.bz2
+# , extracts it into subfolder "wxWidgets-3.2.7",
+# then builds wxWidgets into subfolder "wxWidgets-3.2.7/build-msw",
+# and finally installs wxWidgets into folder "/usr/local/wx3.2.7-msw",
 # 
 # Note: on a normal Linux installation, you will need to "sudo" in order to write to folder
 # /usr/local ; however, Cygwin uses the Windows folder permissons model; so if you
@@ -30,8 +30,8 @@
 [[ -z "$WINDMC"  ]] && export WINDMC=/bin/x86_64-w64-mingw32-windmc.exe
 [[ -z "$WINDRES" ]] && export WINDRES=/bin/x86_64-w64-mingw32-windres.exe
 
-for VER in 3.1.5; do
-#for VER in 3.0.2 3.0.4 3.1.0 3.1.1 3.1.2 3.1.3 3.1.4 3.1.5; do
+for VER in 3.2.7; do
+#for VER in 3.0.2 3.0.4 3.1.0 3.1.1 3.1.2 3.1.3 3.1.4 3.1.5 3.2.7; do
   export TYPE=msw
   export VER
 
@@ -53,8 +53,9 @@ for VER in 3.1.5; do
                --prefix=/usr/local/wx${VER}-${TYPE} \
   	     && make -j $( nproc ) && make -j $( nproc ) install || exit 2
 
+  rm /usr/local/bin/wx-config 2> /dev/null
   ln -s /usr/local/wx${VER}-${TYPE}/bin/wx-config /usr/local/bin/wx-config
 
-  # Test the installation, it should print e.g. "Default config is msw-unicode-static-3.1"
+  # Test the installation, it should print e.g. "Default config is msw-unicode-static-3.2"
   /usr/local/bin/wx-config --list
 done

--- a/src/include/vars.h
+++ b/src/include/vars.h
@@ -1722,7 +1722,7 @@ extern int get_address_mmu_rfn_type(uint32 addr);
 extern void reg68k_sanity_check_bitorder(void);
 
 extern char *mspace(lisa_mem_t fn);
-extern int floppy_insert(char *Image);
+extern int floppy_insert(char *Image, uint8 insert_in_upper_floppy_drive);
 extern void apple_1(void);
 extern void apple_2(void);
 extern void apple_3(void);

--- a/src/lib/libdc42/src/libdc42.c
+++ b/src/lib/libdc42/src/libdc42.c
@@ -1551,7 +1551,7 @@ int dc42_create(char *filename, char *volname, uint32 datasize, uint32 tagsize) 
 
    FILE *newimage;
    char pascalstring[64];
-   uint8 i, dskformat, formatbyte;
+   uint8 i, diskencoding, formatbyte;
 
    newimage = fopen(filename, "wb");
    if (!newimage)
@@ -1591,33 +1591,29 @@ int dc42_create(char *filename, char *volname, uint32 datasize, uint32 tagsize) 
    fputc(0, newimage);
    fputc(0, newimage);
 
-   dskformat = 93;
-   formatbyte = 0x22;
+   diskencoding = 0x03; // 0x00 = Sony400k, 0x01 = Sony800k, 0x54 = Twiggy, 0x02 and 0x03 are for MFM disks
+   formatbyte = 0x96; // 0x01 = Twiggy, 0x02 = Sony400k, 0x22 = Sony800k, 0x96 = Invalid
    if (datasize == 800 * 512 && tagsize == 800 * 12)
    {
-      dskformat = 0;
-      formatbyte = 0x12;
+      // Sony400k:
+      diskencoding = 0x00;
+      formatbyte = 0x02;
    }
-   if (datasize == 1600 * 512 && tagsize == 1600 * 12)
-      dskformat = 1;
-
-   if (datasize == 800 * 512 && tagsize == 0)
+   else if (datasize == 1600 * 512 && tagsize == 1600 * 12)
    {
-      dskformat = 0;
-      formatbyte = 0x12;
+      // Sony800k:
+      diskencoding = 0x01;
+      formatbyte = 0x22;
    }
-   if (datasize == 1600 * 512 && tagsize == 0)
-      dskformat = 1;
-   if (datasize == 720 * 1024 && tagsize == 0)
-      dskformat = 2;
-   if (datasize == 1440 * 1024 && tagsize == 0)
-      dskformat = 3;
+   else if (datasize == 1702 * 512 && tagsize == 1702 * 12)
+   {
+      // Twiggy:
+      diskencoding = 0x54;
+      formatbyte = 0x01;
+   }
 
-   if (dskformat == 93)
-      formatbyte = 0x93; // non-standard disk image
-
-   fputc(dskformat, newimage);  // diskformat
-   fputc(formatbyte, newimage); // diskformat
+   fputc(diskencoding, newimage);  // disk encoding 
+   fputc(formatbyte, newimage); // format byte
 
    fputc(1, newimage);
    fputc(0, newimage); // private flag

--- a/src/lisa/cpu_board/romless.c
+++ b/src/lisa/cpu_board/romless.c
@@ -78,7 +78,8 @@ extern char *los_error_code(signed long loserror);
 #define FLOP_STAT_NOSPED 0x1B  // Unable to adjust speed
 #define FLOP_STAT_NWCALB 0x1c  // Unable to write calibration
 
-extern DC42ImageType current_floppy_image; // in floppy.c, slightly cheating here.
+extern DC42ImageType current_upper_floppy_image;
+extern DC42ImageType current_lower_floppy_image; // in floppy.c, slightly cheating here.
 
 extern long deinterleave5(long sector);
 
@@ -907,8 +908,8 @@ void romless_twgread(void)
   sector = (reg68k_regs[1] >> 8) & 0xff;
   track = (reg68k_regs[1]) & 0xff;
 
-  F = &current_floppy_image;
-  if (!F)
+  F = (drive == 0x00)? &current_upper_floppy_image:&current_lower_floppy_image;
+  if (!F || F->RAM == NULL)
   {
     reg68k_regs[0] = FLOP_STAT_INVSEC;
     reg68k_sr.sr_struct.c = 1;


### PR DESCRIPTION
Added support for both Twiggy floppy drives in Lisa 1 mode. Also, a large cleanup and documenting of the existing floppy-drive-related code.

Regression testing:
I tested installing LOS2, LOS3, Pascal Workshop 3 and Macintosh XL 3 from floppies. All work great, without a single failure. Also, I tried inserting and ejecting all kinds of floppy images files once booted into LOS3. Lisa behaves properly.

The support for Twiggy floppy drives in LisaEm is complete.
Now you can install LOS1.0 from twiggy floppies in the following way:
Use "H" Rom and "40" I/O rom. Keep the "Boot Rom Speedup Hacks" and "Hard Drive Acceleration" checkboxes checked.
Restart the emulator, insert LOS1.0 1 disk (it goes into the upper drive 1) and click on the drive 1 icon in the boot menu to boot from it.
If asked to erase or initialize the Profile, choose Yes.
It will prompt you to insert LOS1.0 disk 2 in the lower drive. To do so, hold down the "shift" button on your keyboard and choose the "Insert Diskette" menu. Choose  the LOS1.0 disk 2 image file . It goes into the lower drive 2. The installation recognizes the disk and continues.  Follow the prompts to complete the installation , reboot and then boot from the ProFile. You are in LOS 1.0. It will pop up a dialog saying that it can't recognize the floppy in the upper drive 1. Just cancel that dialog. I wasn't able to figure out why Lisa thinks that there is a disk in the upper drive 1. The code properly returns "no disk" status, and yet Lisa thinks that there is a disk.

Enjoy!

