### PR TITLE
Implemented ejecting a floppy disk, which mimics a user clicking on the floppy drive eject button

### DIFF
--- a/src/include/vars.h
+++ b/src/include/vars.h
@@ -938,7 +938,6 @@ GLOBAL(int, has_lisa_xl_screenmod, 0);
 #define LISA_XENIX_RUNNING 5
 #define LISA_UNIPLUS_RUNNING 6
 #define LISA_UNIPLUS_SUNIX_RUNNING 7
-#define LISA_SMALLTALK_RUNNING 8
 #define UNKNOWN_OS_RUNNING 100
 
 GLOBAL(int, running_lisa_os, LISA_ROM_RUNNING);
@@ -1724,6 +1723,7 @@ extern void reg68k_sanity_check_bitorder(void);
 
 extern char *mspace(lisa_mem_t fn);
 extern int floppy_insert(char *Image, uint8 insert_in_upper_floppy_drive);
+extern void floppy_eject_button_pressed(uint8 on_upper_floppy_drive) ;
 extern void apple_1(void);
 extern void apple_2(void);
 extern void apple_3(void);

--- a/src/lisa/motherboard/glue.c
+++ b/src/lisa/motherboard/glue.c
@@ -360,15 +360,27 @@ int check_running_lisa_os(void)
     DEBUG_LOG(0, "LisaTest v1:%08x v2:%08x", v1, v2);
     return running_lisa_os;
   }
-  else if (
-    ((v1 & 0x000ff000) == 0x000e3000 && (v2 & 0x000ff000) == 0x000e3000) ||  // Lisa Monitor v11.0 - v1=000e32e6 v2=000e3330, Lisa Monitor v11.1 - v1=000e32e6 v2=000e3330
-    ((v1 & 0x000ff000) == 0x000e2000 && (v2 & 0x000ff000) == 0x000e2000))    // Lisa Monitor v11.8 - v1=000e2980 v2=000e2ad2
+  else if ((v1 & 0x000ff000) == 0x000e3000 && (v2 & 0x000ff000) == 0x000e3000) // Lisa Monitor v11.0 - v1=000e32e6 v2=000e3330, Lisa Monitor v11.1 - v1=000e32e6 v2=000e3330
   {
-    // if (lisa_os_mouse_x_ptr!=0x00000fec) ALERT_LOG(0,"Mouse vector changed from %08x,%08x to fec",lisa_os_mouse_x_ptr,lisa_os_mouse_y_ptr);
+    // Note: This setting fixes the mouse pointer in Smalltalk-80 when running it in Lisa Monitor v11.0 or v11.1
+  
+    // Note: There is also Lisa Monitor v11.2, but we could not find floppy disk images
+    // of it on the webs, hence it is unclear if it will work with the settings below.
+    lisa_os_mouse_x_ptr = 0x000010e6;
+    lisa_os_mouse_y_ptr = 0x000010e8;
+    running_lisa_os = LISA_MONITOR_RUNNING;
+    DEBUG_LOG(0, "Lisa Monitor v11.0 or v11.1 Running: v1=%08x v2=%08x", v1, v2);
+    if (monitor_patch)
+      apply_monitor_hle_patches();
+    return running_lisa_os;
+  }
+  else if ((v1 & 0x00ffffff) == 0x000e2980 && (v2 & 0x00ffffff) == 0x000e2ad2) // Lisa Monitor v11.8 - v1=000e2980 v2=000e2ad2  
+  {
+    // Note: This setting fixes the mouse pointer in Smalltalk-80 when running it in Lisa Monitor v11.8
     lisa_os_mouse_x_ptr = 0x000010ea;
     lisa_os_mouse_y_ptr = 0x000010ec;
     running_lisa_os = LISA_MONITOR_RUNNING;
-    DEBUG_LOG(0, "Lisa Monitor v11 Running: v1=%08x v2=%08x", v1, v2);
+    DEBUG_LOG(0, "Lisa Monitor v11.8 Running: v1=%08x v2=%08x", v1, v2);
     if (monitor_patch)
       apply_monitor_hle_patches();
     return running_lisa_os;

--- a/src/lisa/motherboard/glue.c
+++ b/src/lisa/motherboard/glue.c
@@ -288,7 +288,6 @@ uint8 cmp_screen_hash(uint8 *hashtable1, uint8 *hashtable2)
 #define LISA_XENIX_RUNNING 5
 #define LISA_UNIPLUS_RUNNING 6
 #define LISA_UNIPLUS_SUNIX_RUNNING 7
-#define LISA_SMALLTALK_RUNNING 8
 #define UNKNOWN_OS_RUNNING 100
 
 // remove me


### PR DESCRIPTION
Implemented ejecting a floppy disk, which mimics a user clicking on the floppy drive eject button.

How it works:
If a floppy is already inserted and the user mouse-clicks in the floppy drive area of the lisa skin,
we pop a "Do you want to eject the diskette?" Yes/No dialog.
If yes, we trigger a  Floppy IRQ, the Lisa software intercepts it, and it sends a "floppy eject" command FLOP_CMD_UCLAMP, and we process it (in floppy.c) and eject the floppy.
I did not add a new "Eject Diskette" menu item, to keep things simple.

Why I chose to do this:
The PascalWorkshop1.0 installer asks me do eject floppy disk 2 from the lower drive and then insert disk 3. So I can't finish the installation without this.

Note 1: To eject the lower floppy in Lisa 1 mode, hold the "Shift" key and then click on the floppy drive (this is needed because the lisa skin shows only one floppy drive).
Note 2: Lisa may refuse to act on the IRQ, and hence refuse to eject the floppy. This is evident at the bios boot menu screen.
Note 3: There is also another way to eject a floppy: if we are booted into e.g. LOS3.1, we can eject a floppy using Lisa's menu.

In this commit I also removed the macro "LISA_SMALLTALK_RUNNING" which is not needed and is a leftover from my previous work on fixing the mouse cursor in Smalltalk.

