### PR TITLE
Fixed a bug in ProFile code: MacWorksXL3.0 cannot boot from the ProFile, have to use the boot floppy disk to boot.

### DIFF
--- a/src/include/vars.h
+++ b/src/include/vars.h
@@ -888,6 +888,12 @@ typedef struct
                   // PA gets data out and CA2 is set.  So to avoid a bug where an extra ORA is made when
                   // DDRA=FF, ORA is written, DDRA=0, then DDRA=FF, this keeps track of the pending.
 
+  uint8 last_port;// Some Lisa software (e.g. MacWorksXL3.0 boot routines) write the same byte to the VIA twice: 
+                  // once to port ORANH2 (NH means "no handshake"), and then again to ORA2. 
+                  // We need to ignore the 2nd write, otherwise Lisa does not boot (we get a Lisa error 75).
+                  // Here we store the last port used, so that when writing to ORA2 we could check if the last
+                  // port was ORANH2 and the last value was the same, and ignore the write. 
+
   XTIMER t1_e; // e_clock trigger - at what point will the via clock expire vs cpu68k_clocks
   XTIMER t1_fired;
   XTIMER t2_e;


### PR DESCRIPTION
Fixed a bug in ProFile code: MacWorksXL3.0 cannot boot from the ProFile, have to use the boot floppy disk to boot. It seems this bug was always there.

pablo_marx@ did an excellent analysis of the bug at https://lisalist2.com/index.php/topic,87.msg4394.html#msg4394 ,
and I just had to find the relevant code and fix it it in a similar way to his proposed fix.

Here is what I wrote in vars.h:
Some Lisa software (e.g. MacWorksXL3.0 boot routines) write the same byte to the VIA twice: 
once to port ORANH2 (NH means "no handshake"), and then again to ORA2. 
 We need to ignore the 2nd write, otherwise Lisa does not boot (we get a Lisa error 75).
 To do so, I introduced a new variable "last_port", where we store the last port used, 
so that when writing to ORA2 we could check if the last port was ORANH2 and the last value was the same, 
and ignore the write. 

Now MacWorksXL3.0 boot successfully from the ProFile.

I did some good amount of regression testing this change, with various Lisa software.
Things seems to be working fine.
