### PR TITLE
disable the floppy eject functionality (when clicking with the mouse in…

### DIFF
--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -7052,7 +7052,10 @@ void LisaWin::OnMouseMove(wxMouseEvent &event)
           {
             if(lisa_one_mode) 
             {
-              // Lisa 1 mode with two floppy drives:
+              // Lisa 1 mode with two Twiggy floppy drives:
+              // LOS1.0 does not provide a way to eject a floppy disk, so the only way to do so is by clicking in the floppy area
+              // (or hold Shift + click to eject the lower floppy disk 2),
+              // which triggers this code; it fires a Floppy eject IRQ.
               bool is_shift_key_down = wxGetKeyState(WXK_SHIFT);
               if(!is_shift_key_down && is_upper_floppy_currently_inserted())
               {
@@ -7081,23 +7084,14 @@ void LisaWin::OnMouseMove(wxMouseEvent &event)
             }
             else
             {
-              // Lisa 2 mode with one floppy drive (which is the lower drive):
-              if(is_lower_floppy_currently_inserted())
-              {
-                if (yesnomessagebox("Do you want to eject the diskette?\n\n"
-                  "Note that the currently running Lisa software may ignore the eject request.", "") != 0) 
-                {
-                  floppy_eject_button_pressed(0); // 0 means "lower drive"
-                } 
-              }
-              else
-              {
-                // Show the "open floppy image file" dialog:
-                if (event.LeftDown())
-                  my_lisaframe->OnxFLOPPY();
-                else if (event.RightDown())
-                  my_lisaframe->OnxNewFLOPPY();
-              }
+              // Lisa 2 mode with one floppy drive.
+              // The Lisa 2 does not have a physical floppy eject button, and also the Lisa 2 software
+              // (e.g LOS3.0) ignores any floppy eject IRQ requests; Hence, we don't attempt to eject
+              // the floppy here. So just show the "open floppy image file" dialog:
+              if (event.LeftDown())
+                my_lisaframe->OnxFLOPPY();
+              else if (event.RightDown())
+                my_lisaframe->OnxNewFLOPPY();
             }
           }
         }
@@ -8294,8 +8288,7 @@ void LisaEmFrame::OnxFLOPPY(void)
     else if(!lisa_one_mode && is_lower_floppy_currently_inserted()) 
     {
       wxMessageBox(_T("A previously inserted diskette is still in the drive. "
-        "Please eject the diskette before inserting another.\n\n"
-        "Tip: to eject it, click somewhere in the floppy drive area."),
+        "Please eject the diskette before inserting another.\n"),
         _T("Diskette is already inserted!"), wxICON_INFORMATION | wxOK);
       return;
     }

--- a/src/lisa/io_board/floppy.c
+++ b/src/lisa/io_board/floppy.c
@@ -1800,20 +1800,20 @@ int floppy_insert(char *Image, uint8 insert_in_upper_floppy_drive) // emulator s
     {
         char message[] = "You are trying to use a Twiggy floppy image file in Lisa 2 mode, but it is intended to be used in Lisa 1 mode, with Lisa 1 software. This may not end well.\n\n"
             "Tips for booting from a Twiggy floppy disk image:\n"
-            "  - In the File->Preferences menu, choose I/O ROM version 40 (there's no need to modify the Lisa ROM). "
+            "  - In the File->Preferences menu, switch to Lisa 1 mode by choosing I/O ROM version 40 and any Lisa ROM file. "
             "Apply and restart the emulator.\n"
-            "  - Insert a Twiggy diskette (File->Insert diskette).\n"
-            "  - At the boot screen, click on the upper floppy drive 1 icon to boot from it."; 
+            "  - Insert a Twiggy diskette in the upper drive 1 (File->Insert diskette).\n"
+            "  - At the Lisa boot screen, click on the upper floppy drive 1 icon to boot from it."; 
         messagebox(message, "This may not end well :(");
     }
     else if (floppy_ram[ROMVER]==0x40 && F->ftype!=0) 
     {
         char message[] = "You are trying to use a Sony floppy image file in Lisa 1 mode, but it is intended to be used in Lisa 2 mode, with Lisa 2 software. This may not end well.\n\n"
             "Tips for booting from a Sony floppy disk image:\n"
-            "  - In the File->Preferences menu, choose any I/O ROM version but 40 (there's no need to modify the Lisa ROM). "
+            "  - In the File->Preferences menu, switch to Lisa 2 mode by choosing any I/O ROM version EXCEPT version 40, and a ROM file version H or 3A. "
             "Apply and restart the emulator.\n"
             "  - Insert a Sony diskette (File->Insert diskette).\n"
-            "  - At the boot screen, click on the floppy drive icon to boot from it."; 
+            "  - At the Lisa boot screen, click on the floppy drive icon to boot from it."; 
         messagebox(message, "This may not end well :(");
     }
 


### PR DESCRIPTION
Disable the floppy eject functionality (when clicking with the mouse in the floppy drive area on the Lisa skin) in Lisa 2 mode, because the Lisa 2 software (e.g., LOS 3.0) ignores our eject IRQ requests and hence the floppy does not get ejected. Ejecting still works in Lisa 1 mode (e.g. in LOS 1.0), and in fact it's the only way to eject the floppy in LOS 1.0.

Note: it makes sense that the Lisa 2 software is ignoring our floppy eject IRQ requests, because Lisa 2 (and XL) does not have a physical floppy eject button.