### PR TITLE
Added support for raw Profile image files,  like the ones used by popular hardware emulators: IDEFile, ESProfile, Cameo/Aphid and others.

### DIFF
--- a/src/host/wxui/LisaConfigFrame.cpp
+++ b/src/host/wxui/LisaConfigFrame.cpp
@@ -140,7 +140,7 @@ LisaConfigFrame::LisaConfigFrame(const wxString &title, LisaConfig *lisaconfig)
     pportopts[1] = wxT("ADMP");
     pportopts[2] = wxT("Nothing");
 
-    wpportopts[0] = wxT("Widget-10");
+    wpportopts[0] = wxT("Widget");
     wpportopts[1] = wxT("ADMP");
     wpportopts[2] = wxT("Nothing");
 
@@ -812,20 +812,12 @@ wxPanel *LisaConfigFrame::CreatePortsConfigPage(wxNotebook *parent)
 
     y += ya * 2;
 
-    if (floppy_iorom != 0x88)
-    {
-        pportbox = new wxRadioBox(panel, wxID_ANY,
-                                  wxT("Parallel Port:"), wxPoint(10, y), wxDefaultSize, 3, pportopts, 0, wxRA_SPECIFY_COLS,
+    pportbox = new wxRadioBox(panel, wxID_ANY,
+                                  wxT("Parallel Port:"), wxPoint(10, y), wxDefaultSize, 3, 
+                                  (floppy_iorom == 0x88)? wpportopts:pportopts, // Display "Profile" or "Widget" on the radio button, depending on the IO ROM version.
+                                  0, wxRA_SPECIFY_COLS,
                                   wxDefaultValidator, wxT("radioBox"));
-        my_lisaconfig->parallelp.Replace(_T("widget"), _T("profile"), true);
-    }
-    else
-    {
-        pportbox = new wxRadioBox(panel, wxID_ANY,
-                                  wxT("Parallel Port:"), wxPoint(10, y), wxDefaultSize, 1, wpportopts, 0, wxRA_SPECIFY_COLS,
-                                  wxDefaultValidator, wxT("radioBox"));
-        my_lisaconfig->parallelp.Replace(_T("profile"), _T("widget"), true);
-    }
+
     y += ya * 2;
 
     // default to profile for builtin parallel port
@@ -960,8 +952,8 @@ void LisaConfigFrame::OnPickProFile(wxCommandEvent &WXUNUSED(event))
 {
     wxFileDialog open(this, wxT("Store ProFile drive as:"),
                       wxEmptyString,
-                      (floppy_iorom == 0x88) ? wxT("lisaem-widget.dc42") : wxT("lisaem-profile.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("lisaem-profile.dc42"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       (long int)wxFD_SAVE, wxDefaultPosition);
 
     if (open.ShowModal() == wxID_OK)
@@ -975,7 +967,7 @@ void LisaConfigFrame::OnPickProFile1H(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on upper port of Slot 1 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s1h.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
     if (open.ShowModal() == wxID_OK)
         m_text_propathh[1]->SetValue(open.GetPath());
@@ -986,7 +978,7 @@ void LisaConfigFrame::OnPickProFile1L(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on lower port of Slot 1 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s1l.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
     if (open.ShowModal() == wxID_OK)
         m_text_propathl[1]->SetValue(open.GetPath());
@@ -999,7 +991,7 @@ void LisaConfigFrame::OnPickProFile2H(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on upper port of Slot 2 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s2h.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
 
     if (open.ShowModal() == wxID_OK)
@@ -1011,7 +1003,7 @@ void LisaConfigFrame::OnPickProFile2L(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on lower port of Slot 2 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s2l.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
 
     if (open.ShowModal() == wxID_OK)
@@ -1024,7 +1016,7 @@ void LisaConfigFrame::OnPickProFile3H(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on upper port of Slot 3 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s3h.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
 
     if (open.ShowModal() == wxID_OK)
@@ -1036,7 +1028,7 @@ void LisaConfigFrame::OnPickProFile3L(wxCommandEvent &WXUNUSED(event))
     wxFileDialog open(NULL, wxT("Create ProFile drive on lower port of Slot 3 as:"),
                       wxEmptyString,
                       wxT("lisaem-profile-s3l.dc42"),
-                      wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                      wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                       wxFD_SAVE);
 
     if (open.ShowModal() == wxID_OK)

--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -266,6 +266,9 @@ extern "C" uint8 is_lower_floppy_currently_inserted(void);
 // defined in in floppy.c:
 extern uint32 total_num_sectors_read;
 extern uint32 total_num_sectors_written;
+// defined in profile.c:
+extern uint32 profile_total_num_sectors_read;
+extern uint32 profile_total_num_sectors_written;
 
 void iw_check_finish_job(void);
 
@@ -1808,7 +1811,7 @@ void LisaEmFrame::Update_Status(long elapsed,long idleentry)
     }
 
     text.Printf(_T("CPU: %1.2f%s want:%1.2fMHz tick:%d, video refresh:%1.2f%s %c contrast:%02x %s %x%x:%x%x:%x%x.%x @%d/%08x "
-        "clk_cycles:%lld Floppy_sectors_R/W:%d/%d"),
+        "clk_cycles:%lld  Floppy_sectors_R/W:%d/%d  Profile_sectors_R/W:%d/%d"),
         mhzactual, c, throttle, emulation_tick,
         vidhz, s, (videoramdirty ? 'd' : ' '),
         contrast,
@@ -1818,7 +1821,8 @@ void LisaEmFrame::Update_Status(long elapsed,long idleentry)
         lisa_clock.secs_h, lisa_clock.secs_l,
         lisa_clock.tenths,
         context, pc24, cpu68k_clocks,
-        total_num_sectors_read, total_num_sectors_written
+        total_num_sectors_read, total_num_sectors_written,
+        profile_total_num_sectors_read, profile_total_num_sectors_written
       );
 
     SetStatusBarText(text);
@@ -9412,14 +9416,9 @@ void connect_device_to_via(int v, wxString device, wxString *file, wxString prof
                                        _T("lisaem-s2l-profile.dc42"),
                                        _T("lisaem-s3h-profile.dc42"),
                                        _T("lisaem-s3l-profile.dc42")};
-        static const wxString widget = "lisaem-widget";
-
         if (v > 1 && v < 9)
         {
-          if (v == 2 && my_lisaconfig->iorom == 0x88)
-            *file = wxStandardPaths::Get().GetAppDocumentsDir() + wxFILE_SEP_PATH + widget;
-          else
-            *file = wxStandardPaths::Get().GetAppDocumentsDir() + wxFILE_SEP_PATH + def[v];
+          *file = wxStandardPaths::Get().GetAppDocumentsDir() + wxFILE_SEP_PATH + def[v];
         }
         else
           return; // invalid via index
@@ -10263,7 +10262,7 @@ extern "C" int pickprofilesize(char *filename, int allowexisting)
         wxFileDialog open(my_lisaframe, wxT("Select an ProFile hard drive image"),
                           wxEmptyString,
                           wxEmptyString,
-                          wxT("Disk Copy (*.dc42)|*.dc42|All (*.*)|*.*"),
+                          wxT("Disk Image (*.dc42;*.image)|*.dc42;*.image|All (*.*)|*.*"),
                           (long int)wxFD_OPEN, wxDefaultPosition);
 
         if (open.ShowModal() == wxID_OK)

--- a/src/include/vars.h
+++ b/src/include/vars.h
@@ -503,10 +503,6 @@ ACGLOBAL(uint8, highest_bit_val_inv[],
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define MAXIRQQUEUE 64
 
-// *** WARNING Make sure you copy the above to vars.c as
-// it does not include vars.h
-#define PROFILE_IMG_HEADER_SIZE 2048
-
 /* Defines for the Via 6522 code -- MMU needs these to decypher the register accessed. */
 // Expansion Port Slots.  PARPORTVER is the ROM version number.
 #define PARPORTVER   \

--- a/src/lib/libdc42/README.md
+++ b/src/lib/libdc42/README.md
@@ -13,7 +13,7 @@ The library itself is used by LisaEm as well as DiskCopy 4.2 specific tools.
 
 On systems that support memory mapping, it uses the mmap function to load the whole image into RAM and uses the page in/out features of your OS for speed.
 
-Disk Copy 4.2 is an old world, classic MacOS (i.e. System 6-9) 68000 application. The Disk image format is stored in .Image files, but I use .dc42 to make it more clear as to what it is. Such disk images are used for Macintosh floppies, Lisa Floppies, and in some cases even Apple ][ floppies.
+Disk Copy 4.2 is an old world, classic MacOS (i.e. System 6-9) 68000 application. I recommend using the .dc42 file extension to make it more clear as to what it is. Such disk images are used for Macintosh floppies, Lisa Floppies, and in some cases even Apple ][ floppies.
 
 LibDC42 has an interface similar to the fopen, fread/frwrite fclose API of libstdc, except that creating a new disk image does not open it. A DC42ImageType structure pointer is passed arround to the functions when various operations are called. The open function can take extra parameters flagging whether to use memory mapping (when available), whether to access an image in Read Only format, and so on. Upon closing the DC42ImageType file, checksums are recalculated and saved. Additionally the errormsg structure member is used to store informational messages when an error occurs and should be used to display error messages to the user as they occur. The retval (return value) member is equivalent to the errno variable, and when set is an indicator that an error has occured and that errormsg should be passed to the user.
 
@@ -152,6 +152,10 @@ int dc42_open_by_handle(DC42ImageType *F, int fd, FILE *fh, long seekstart, char
                                                                                    // i.e. if you use 'w', the fd must have been opened
                                                                                    // in read/write mode, not read only!
 
+int raw_profile_image_open(DC42ImageType *F, char *filename, char *options)        // opens a raw profile disk image,
+                                                                                   // like the ones used by popular hardware emulators:
+                                                                                   // IDEFile, ESProfile, Cameo/Aphid and future ones.
+
 
 F: pointer to DC42ImageType - you must allocate this yourself before calling the open function.  You'll need to pass the pointer
                       to this structure to most of these calls.
@@ -283,14 +287,14 @@ typedef struct                          // floppy type
   uint8  ftype;                         // floppy type 0=twig, 1=sony400k, 2=sony800k, 3=freeform, 254/255=disabled
 
 
-  uint32 tagsize;                       // must set to 12 - expect ProFile/Widget to use 24 byte tags
-  uint32 datasize;                      // must set to 512
+  uint32 tagsize;                       // 12 for floppy disk images, 20 for ProFile/Widget hard disk images
+  uint32 datasize;                      // must set to 512. TODO: remove this attribute and use sectorsize instead
 
   uint32 datasizetotal;                 // data size (in bytes of all sectors added together)
   uint32 tagsizetotal;                  // tag size total in bytes
 
   uint32 sectoroffset;                  // how far into the file is the 1st sector
-  uint16 sectorsize;                    // must set to 512  (Twiggies might be 256 bytes/sector, but unknown)
+  uint16 sectorsize;                    // must set to 512
   uint32 tagstart;                      // how far into the file to 1st tag - similar to sectoroffset
 
   uint32 maxtrk, maxsec,maxside, numblocks;  // unused by these routines, but used by the Lisa Emulator
@@ -390,5 +394,8 @@ extern int dc42_extract_macbinii(char *infilename);                             
                                                                                    // NOTE: filename is overwritten with
                                                                                    // extracted file name!  On negative return
                                                                                    // the filename has been altered!
-```
 
+int raw_profile_image_open(DC42ImageType *F, char *filename, char *options);       // opens a raw profile disk image,
+                                                                                   // like the ones used by popular hardware emulators:
+                                                                                   // IDEFile, ESProfile, Cameo/Aphid and future ones.
+```

--- a/src/lib/libdc42/build.sh
+++ b/src/lib/libdc42/build.sh
@@ -83,7 +83,7 @@ then
 fi
 
 CHECKDIRS include lib obj resources src
-CHECKFILES libdc42-lgpl-license.txt libdc42-gpl-license.txt include/libdc42.h src/libdc42.c resources/libdc42-banner.png
+CHECKFILES libdc42-lgpl-license.txt libdc42-gpl-license.txt include/libdc42.h src/libdc42.c src/lib_raw_profile_image.c resources/libdc42-banner.png
 
 # Parse command line options if any, overriding defaults.
 #echo parsing options
@@ -278,9 +278,16 @@ COMPILED=""
 if needed libdc42.c ../obj/libdc42.o || needed libdc42.c ../lib/libdc42.a; then
    qjob "!!  Compiled libdc42.c..." $CC -W $WARNINGS -Wstrict-prototypes $INC -Wno-format -Wno-unused  $WITHDEBUG $WITHTRACE $ARCH $CFLAGS -c libdc42.c -o ../obj/libdc42.o || exit 1
    waitqall
+fi
 
-   echo "  Making libdc42.a library..." 1>&2
-   makelibs  ../lib libdc42 "${VERSION}" static ../obj/libdc42.o
+if needed lib_raw_profile_image.c ../obj/lib_raw_profile_image.o || needed lib_raw_profile_image.c ../lib/libdc42.a; then
+   qjob "!!  Compiled lib_raw_profile_image.c..." $CC -W $WARNINGS -Wstrict-prototypes $INC -Wno-format -Wno-unused  $WITHDEBUG $WITHTRACE $ARCH $CFLAGS -c lib_raw_profile_image.c -o ../obj/lib_raw_profile_image.o || exit 1
+   waitqall
+fi
+
+if needed ../obj/libdc42.o ../lib/libdc42.a || needed ../obj/lib_raw_profile_image.o ../lib/libdc42.a; then
+    echo "  Making libdc42.a library..." 1>&2
+    makelibs  ../lib libdc42 "${VERSION}" static "../obj/libdc42.o ../obj/lib_raw_profile_image.o"
 fi
 
 cd ..

--- a/src/lib/libdc42/include/libdc42.h
+++ b/src/lib/libdc42/include/libdc42.h
@@ -337,14 +337,14 @@ struct DC42ImageType {
 
   uint8 ftype; // floppy type 0=twig, 1=sony400k, 2=sony800k, 3=freeform, 254/255=disabled
 
-  uint32 tagsize;  // must set to 12 - expect ProFile/Widget to use 24 byte tags
-  uint32 datasize; // must set to 512
+  uint32 tagsize;  // 12 for floppy disk images, 20 for ProFile/Widget hard disk images
+  uint32 datasize; // must set to 512. TODO: remove this attribute and use sectorsize instead
 
   uint32 datasizetotal; // data size (in bytes of all sectors added together)
   uint32 tagsizetotal;  // tag size total in bytes
 
   uint32 sectoroffset; // how far into the file is the 1st sector
-  uint16 sectorsize;   // must set to 512  (Twiggies might be 256 bytes/sector, but unknown)
+  uint16 sectorsize;   // must set to 512 
   uint32 tagstart;     // how far into the file to 1st tag - similar to sectoroffset
 
   uint32 maxtrk, maxsec, maxside, numblocks; // unused by these routines, but used by the Lisa Emulator
@@ -424,5 +424,7 @@ int dc42_extract_macbinii(char *infilename); // extracts macbin2 header if one e
 
 int searchseccount(DC42ImageType *F, int sector, int size, uint8 *s);
 int replacesec(DC42ImageType *F, int sector, int size, uint8 *s, uint8 *r);
+
+int raw_profile_image_open(DC42ImageType *F, char *filename, char *options);
 
 ////////////// headers ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/lib/libdc42/src/lib_raw_profile_image.c
+++ b/src/lib/libdc42/src/lib_raw_profile_image.c
@@ -61,10 +61,6 @@
 #include <sys/mman.h>
 #include <glob.h>
 #define HAVE_MMAPEDIO
-#else
-#define strncasecmp _strnicmp
-#define strcasecmp _stricmp
-#include <strcasestr.h>
 #endif
 
 #include <errno.h>

--- a/src/lib/libdc42/src/lib_raw_profile_image.c
+++ b/src/lib/libdc42/src/lib_raw_profile_image.c
@@ -1,0 +1,655 @@
+/**************************************************************************************\
+*                                     LibDC42                                          *
+*                                                                                      *
+*                       A Part of the Lisa Emulator Project                            *
+*                                                                                      *
+*                  Copyright (C) 2025 Friends of Ray Arachelian                        *
+*                                All Rights Reserved                                   *
+*                                                                                      *
+*           This program is free software; you can redistribute it and/or              *
+*           modify it under the terms of the GNU General Public License                *
+*           as published by the Free Software Foundation; either version 2             *
+*           of the License, or (at your option) any later version.                     *
+*                                                                                      *
+*           This program is distributed in the hope that it will be useful,            *
+*           but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+*           MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+*           GNU General Public License for more details.                               *
+*                                                                                      *
+*           You should have received a copy of the GNU General Public License          *
+*           along with this program;  if not, write to the Free Software               *
+*           Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *
+*                                                                                      *
+*                   or visit: http://www.gnu.org/licenses/gpl.html                     *
+*                                                                                      *
+*                                                                                      *
+*        Routines for access and manipulation of "raw" Apple Profile and Widget        *
+*        hard disk image files, like the ones used by popular hardware emulators:      *
+*        IDEFile, ESProfile, Cameo/Aphid and probably other future ones.               *
+*                                                                                      *
+*        The file format is: a set of 532-byte "sectors", where                        *
+*        each sector has 20 bytes of tag data followed by 512 bytes of sector data.    *
+*        The sectors are stored in a 5:1 interleave order, see                         *
+*        function interleave5() below for details.                                     *
+*                                                                                      *
+*        The files usually have a ".image" file extension, but other extensions        *
+*        can be used as well.                                                          *
+*                                                                                      *
+*        There is no way to validate that a given file is indeed of this type.          *
+*                                                                                      *
+*        A typical 5MB Profile hard disk image is of file size 5,176,320 bytes,        *
+*        which has 9,729 sectors (of size 512+20) bytes, and 492 unused bytes          *
+*        at the end (a file with 0 unused bytes would work just as good).              *
+*                                                                                      *
+*        A lot of the code here has been adapted from libdc42.c.                       *
+*                                                                                      *
+\**************************************************************************************/
+
+// needed for LisaEm compatibility, you can remove this, but you must
+// define int8, int16, int32, uint8, uint16, uint32.
+#include <machine.h>
+
+#include "libdc42.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+// Windows lacks MMAP, strcasestr functions
+#ifndef __MSVCRT__
+#include <sys/mman.h>
+#include <glob.h>
+#define HAVE_MMAPEDIO
+#else
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#include <strcasestr.h>
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <strings.h>
+#include <ctype.h>
+
+#ifndef fgetc
+#define fgetc(xx) ((unsigned)(getc(xx)))
+#endif
+
+// Here we reuse the macros found in libdc42.c for error checking and returning. See some relevant comments there.
+#define RAW_PROFILE_RET_CODE(F, code, msg, ret) \
+   {                                     \
+      if (F)                             \
+      {                                  \
+         F->retval = code;               \
+         F->errormsg = msg;              \
+         ret;                            \
+      }                                  \
+   }
+
+
+#define RAW_PROFILE_CHECK_VALID_F(F)                                                                      \
+   {                                                                                               \
+      if (!F)                                                                                      \
+         return -1;                                                                                \
+      if (!F->RAM)                                                                                 \
+      {                                                                                            \
+         RAW_PROFILE_RET_CODE(F, -3, "Disk image closed or no memory allocated to it", return F->retval); \
+      }                                                                                            \
+      if (F->fd < 3 && !F->fh)                                                                     \
+      {                                                                                            \
+         RAW_PROFILE_RET_CODE(F, -5, "Invalid file descriptor", return F->retval);                        \
+      }                                                                                            \
+   }
+
+#define RAW_PROFILE_CHECK_VALID_F_NUL(F)                                                             \
+   {                                                                                          \
+      if (!F)                                                                                 \
+         return NULL;                                                                         \
+      if (!F->RAM)                                                                            \
+         RAW_PROFILE_RET_CODE(F, -3, "Disk image closed or no memory allocated to it", return NULL); \
+      if (F->fd < 3 && !F->fh)                                                                \
+         RAW_PROFILE_RET_CODE(F, -5, "Invalid file descriptor", return NULL);                        \
+   }
+
+#define RAW_PROFILE_CHECK_VALID_F_ZERO(F)                                                         \
+   {                                                                                       \
+      if (!F)                                                                              \
+         return 0;                                                                         \
+      if (!F->RAM)                                                                         \
+         RAW_PROFILE_RET_CODE(F, -3, "Disk image closed or no memory allocated to it", return 0); \
+      if (F->fd < 3 && !F->fh)                                                             \
+         RAW_PROFILE_RET_CODE(F, -5, "Invalid file descriptor", return 0);                        \
+   }
+
+#define RAW_PROFILE_CHECK_WRITEABLE(F)                                        \
+   {                                                                   \
+      if (F->readonly)                                                 \
+         RAW_PROFILE_RET_CODE(F, -8, "Image is Read Only", return F->retval); \
+   }
+#define RAW_PROFILE_CHECK_WRITEABLE1(F)                                       \
+   {                                                                   \
+      if (F->readonly == 1)                                            \
+         RAW_PROFILE_RET_CODE(F, -8, "Image is Read Only", return F->retval); \
+   }
+
+
+// like fsync, sync's writes back to the file.
+int raw_profile_sync_to_disk(DC42ImageType *F) 
+{
+   RAW_PROFILE_CHECK_VALID_F(F);
+   RAW_PROFILE_CHECK_WRITEABLE(F);
+
+#ifdef HAVE_MMAPEDIO
+   if (F->mmappedio == 1)
+      msync(F->RAM, F->size, MS_SYNC);
+#endif
+
+   if (F->mmappedio == 2 && F->readonly == 0)
+   {
+      int i;
+
+      if (F->fd > 2)
+      {
+         lseek(F->fd, 0, SEEK_SET);
+         i = write(F->fd, F->RAM, F->size);        // save the whole file
+      }
+
+      if (F->fh)
+      {
+         fseek(F->fh, 0, SEEK_SET);
+         i = fwrite(F->RAM, F->size, 1, F->fh);    // save the whole file
+      }
+
+   }
+
+   if (F->fh)
+      fflush(F->fh);
+#ifndef __MSVCRT__
+   if (F->fd)
+      fsync(F->fd);
+#else
+   if (F->fd)
+      _commit(F->fd);
+#endif
+
+   return 0;
+}
+
+/**
+What is "5:1" interleaving?
+The original ProFile hard disk drive used a 5:1 interleaving scheme to optimize data retrieval times:
+By the time the Lisa processed the sector it just read, the Profile disk platter has moved few sectors further along.
+To avoid waiting for a nearly-full disk rotation to read the next sector, the sectors are interleaved. 
+This optimization speeds up sequential reads.
+
+For sector number  0: interleave(0)=0 
+For sector number  1: interleave(1)=5
+For sector number  2: interleave(2)=10 
+For sector number  3: interleave(3)=15
+For sector number  4: interleave(4)=4
+For sector number  5: interleave(5)=9 
+For sector number  6: interleave(6)=14
+For sector number  7: interleave(7)=3 
+For sector number  8: interleave(8)=8 
+For sector number  9: interleave(9)=13 
+For sector number 10: interleave(10)=2 
+For sector number 11: interleave(11)=7 
+For sector number 12: interleave(12)=12 
+For sector number 13: interleave(13)=1 
+For sector number 14: interleave(14)=6 
+For sector number 15: interleave(15)=11 
+For sector number 16: interleave(16)=16 
+For sector number 17: interleave(17)=21 
+For sector number 18: interleave(18)=26 
+For sector number 19: interleave(19)=31 
+For sector number 20: interleave(20)=20
+... etc ...
+ */
+long interleave5(long sector)
+{
+  static const int offset_delta[] = {0, 4, 8, 12, 0, 4, 8, -4, 0, 4, -8, -4, 0, -12, -8, -4};
+  return sector + offset_delta[(sector & 15)]; // "sector & 15" is an optimized version of "sector % 16"
+}
+
+// Gets the offset in the file (or in the F->RAM) where the tag data for this sectornumber is stored
+// The file format is: a set of sectors, where each sector has 20-bytes tag data followed by 512 bytes sector data. Sectors are interleaved in 5:1 order.
+long get_tag_pos(DC42ImageType *F, long sectornumber) {
+   long interleaved_sector = interleave5(sectornumber);
+   long pos = interleaved_sector * (F->sectorsize + F->tagsize);
+   //fprintf(stderr,"get_tag_pos for sector number:%d ; interleaved_sector:%d ; pos:%d\n", sectornumber, interleaved_sector, pos);
+   return pos;
+}
+
+// Gets the offset in the file (or in the F->RAM) where the sector data for this sectornumber is stored
+long get_data_pos(DC42ImageType *F, long sectornumber) {
+   long interleaved_sector = interleave5(sectornumber);
+   long pos = (interleaved_sector * (F->sectorsize + F->tagsize)) + F->tagsize; // the sector data is after the tag data
+   //fprintf(stderr,"get_data_pos for sector number:%d ; interleaved_sector:%d ; pos:%d\n", sectornumber, interleaved_sector, pos);
+   return pos;
+}
+
+int raw_profile_close_image(DC42ImageType *F)
+{
+   fprintf(stderr,"lib_raw_profile_image.c: Closing raw profile image file %s\n", F->fname);
+   RAW_PROFILE_CHECK_VALID_F(F);
+   raw_profile_sync_to_disk(F);
+
+#ifdef HAVE_MMAPEDIO
+   if (F->mmappedio == 1)
+      munmap(F->RAM, F->size);
+   else
+#endif
+       if (F->RAM)
+      free(F->RAM);
+
+   F->RAM = NULL; // decouple file and RAM, mark RAM as invalid
+
+   if (F->fd > 2)
+   {
+      close(F->fd);
+      F->fd = -1;
+   } // close the file handle.
+
+   if (F->fh)
+   {
+      fclose(F->fh);
+      F->fh = NULL;
+   }
+
+   RAW_PROFILE_RET_CODE(F, 0, "Image Closed", return F->retval);
+   return F->retval; // suppress dumb compiler warning
+}
+
+// Reads the tag data for the specified sectornumber, returns pointer to it
+uint8 *raw_profile_image_read_sector_tags(DC42ImageType *F, uint32 sectornumber)
+{
+   // fprintf(stderr,"lib_raw_profile_image.c: Reading tags for sector number:%d\n", sectornumber);
+   RAW_PROFILE_CHECK_VALID_F_NUL(F);
+   F->retval = 0;
+   F->errormsg = F->returnmsg;
+   *F->returnmsg = 0;
+
+   if (sectornumber >= F->numblocks)
+   {
+      RAW_PROFILE_RET_CODE(F, 999, "invalid sector #", return NULL);
+   }
+
+   if (F->mmappedio == 0)
+   {
+      int i;
+      if (F->fd > 2)
+      {
+         lseek(F->fd, get_tag_pos(F, sectornumber), SEEK_SET);
+         // The RAM buffer is for just 1 sector's data + tag data (sector data is first, then tag data)
+         i = read(F->fd, &F->RAM[F->sectorsize], F->tagsize); // put tag data after the sector data
+         // fprintf(stderr,"fd-read tag %4d at loc:%08x PTR:%p\n",sectornumber,get_tag_pos(sectornumber),F);
+      }
+      if (F->fh)
+      {
+         fseek(F->fh, get_tag_pos(F, sectornumber), SEEK_SET);
+         i = fread(&F->RAM[F->sectorsize], F->tagsize, 1, F->fh); // put tag data after the sector data
+         // fprintf(stderr,"fh-read tag %4d at loc:%08x PTR:%p\n",sectornumber,get_tag_pos(sectornumber),F);
+      }
+
+      return &F->RAM[F->sectorsize]; // with reads of sectors.
+   }
+
+   // otherwise it's either mmapped or fully in RAM, either way, access to them is the same.
+   // fprintf(stderr,"mem-read tag %4d at loc:%08x PTR:%p\n",sectornumber,get_tag_pos(sectornumber),F);
+   return &F->RAM[get_tag_pos(F, sectornumber)];
+}
+
+// Reads the sector data for the specified sectornumber, returns pointer to it
+uint8 *raw_profile_image_read_sector_data(DC42ImageType *F, uint32 sectornumber)
+{
+   // fprintf(stderr,"lib_raw_profile_image.c: Reading data for sector number:%d\n", sectornumber);
+   RAW_PROFILE_CHECK_VALID_F_NUL(F)
+   F->retval = 0;
+   F->errormsg = F->returnmsg;
+   *F->returnmsg = 0;
+
+   if (sectornumber >= F->numblocks)
+   {
+      RAW_PROFILE_RET_CODE(F, 999, "invalid sector #", return NULL);
+   }
+
+   if (!F->mmappedio)
+   {
+      int i;
+      if (F->fd > 2)
+      {
+         lseek(F->fd, get_data_pos(F, sectornumber), SEEK_SET);
+         i = read(F->fd, F->RAM, F->sectorsize);
+         // fprintf(stderr,"fd-read data %4d at loc:%08x PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+      }
+
+      if (F->fh)
+      {
+         fseek(F->fh, get_data_pos(F, sectornumber), SEEK_SET);
+         i = fread(F->RAM, F->sectorsize, 1, F->fh);
+         // fprintf(stderr,"fh-read data %4d at loc:%08x PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+      }
+
+      return F->RAM;
+   }
+
+   //   fprintf(stderr,"Returning code:%d string:%s\n",F->retval,F->errormsg); fflush(stderr);
+   //   fprintf(stderr,"mem-read data %4d at loc:%08x PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+   return &F->RAM[get_data_pos(F, sectornumber)];
+}
+
+// Writes the sector data for the specified sectornumber to the file
+int raw_profile_image_write_sector_data(DC42ImageType *F, uint32 sectornumber, uint8 *data)
+{
+   // fprintf(stderr,"lib_raw_profile_image.c: Writing data for sector number:%d\n", sectornumber);
+   RAW_PROFILE_CHECK_VALID_F(F);
+   RAW_PROFILE_CHECK_WRITEABLE1(F);
+   F->retval = 0;
+   F->errormsg = F->returnmsg;
+   *F->returnmsg = 0;
+
+   if (sectornumber >= F->numblocks)
+   {
+      RAW_PROFILE_RET_CODE(F, 999, "invalid sector #", return 999);
+   }
+
+   if (!F->mmappedio)
+   {
+      int i;
+      //{fprintf(stderr,"lib_raw_profile_image.c::wrote DIRECT! to block#%ld, returning:%ld\n",sectornumber, F->retval); fflush(stderr);}
+      if (F->fd)
+      {
+         lseek(F->fd, get_data_pos(F, sectornumber), SEEK_SET);
+         i = write(F->fd, data, F->sectorsize);
+
+         // fprintf(stderr,"fd-write data %4d at loc:%08x PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+      }
+      if (F->fh)
+      {
+         fseek(F->fh, get_data_pos(F, sectornumber), SEEK_SET);
+         i = fwrite(data, F->sectorsize, 1, F->fh);
+         // fprintf(stderr,"fh-write data %4d at loc:%08x PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+      }
+
+      RAW_PROFILE_RET_CODE(F, 0, "Sector Written", return F->retval);
+   }
+
+   // fprintf(stderr,"mem-write data %4d at loc:%08x  PTR:%p\n",sectornumber,get_data_pos(sectornumber),F);
+   memcpy(&F->RAM[get_data_pos(F, sectornumber)], data, F->sectorsize);
+
+   if (F->synconwrite && F->readonly == 0)
+      raw_profile_sync_to_disk(F);
+
+   //{fprintf(stderr,"lib_raw_profile_image.c::wrote to block#%ld, returning:%ld\n",sectornumber, F->retval); fflush(stderr);}
+
+   RAW_PROFILE_RET_CODE(F, 0, "Sector Written", return F->retval);
+   return F->retval; // suppress dumb compiler warning, even though we never reach here
+}
+
+// Writes the tagdata for the specified sectornumber to the file
+int raw_profile_image_write_sector_tags(DC42ImageType *F, uint32 sectornumber, uint8 *tagdata)
+{
+   // fprintf(stderr,"lib_raw_profile_image.c: Writing tags for sector number:%d\n", sectornumber);
+   RAW_PROFILE_CHECK_VALID_F(F);
+   RAW_PROFILE_CHECK_WRITEABLE1(F);
+   F->retval = 0;
+   F->errormsg = F->returnmsg;
+   *F->returnmsg = 0;
+
+   if (sectornumber >= F->numblocks)
+   {
+      RAW_PROFILE_RET_CODE(F, 999, "invalid sector #", return 999);
+   }
+
+   if (!F->mmappedio)
+   {
+      if (F->fd > 2)
+      {
+         int i;
+         lseek(F->fd, get_tag_pos(F, sectornumber), SEEK_SET);
+         i = write(F->fd, tagdata, F->tagsize);
+         // fprintf(stderr,"fd-write tag %4d at loc:%08x PTR:%p\n",sectornumber,get_tag_pos(sectornumber),F);
+      }
+
+      if (F->fh)
+      {
+         int i;
+         fseek(F->fh, get_tag_pos(F, sectornumber), SEEK_SET);
+         i = fwrite(tagdata, F->tagsize, 1, F->fh);
+         // fprintf(stderr,"fh-write tag %4d at loc:%08x PTR:%p\n",sectornumber,get_tag_pos(sectornumber),F);
+      }
+
+      return 0;
+   }
+
+   memcpy(&F->RAM[get_tag_pos(F, sectornumber)], tagdata, F->tagsize);
+
+   if (F->synconwrite && F->readonly == 0)
+      raw_profile_sync_to_disk(F);
+   //{fprintf(stderr,"lib_raw_profile_image.c::wrote %d tag bytes to block#%ld, returning:%ld\n",F->tagsize, sectornumber, F->retval); fflush(stderr);}
+   RAW_PROFILE_RET_CODE(F, 0, "Sector Tag Written", return F->retval);
+   return F->retval; // suppress dumb compiler warning
+}
+
+// Called from profile.c to open a raw ProFile/Widget hard disk image file; it calls it with options="wb" (w=open in read/write mode, b=make best choice for mmapped I/O or RAM)
+int raw_profile_image_open(DC42ImageType *F, char *filename, char *options)
+{
+   fprintf(stderr,"lib_raw_profile_image.c: Starting in raw_profile_image_open for filename:%s with options:%s\n",filename,options);
+   fflush(stderr);
+
+   int i, flag;
+   long filesizetotal = 0; // total size of the file in bytes
+   F->retval = 0; // success by default
+   F->returnmsg[0] = 0;
+
+   // "configure" the function pointers in DC42ImageType that are used for reading/writing sectors/tags and for closing the image file.
+   // to point to the functions defined in this file. They are being invoked from profile.c
+   F->read_sector_tags = raw_profile_image_read_sector_tags;
+   F->write_sector_tags = raw_profile_image_write_sector_tags;
+   F->read_sector_data = raw_profile_image_read_sector_data;
+   F->write_sector_data = raw_profile_image_write_sector_data;
+   F->close_image = raw_profile_close_image;
+   F->close_image_by_handle = NULL; // not supported for raw profile images
+
+   // copy the file name into the image structure for later use
+   strncpy(F->fname, filename, FILENAME_MAX);
+
+   // open the image file just to get its file size and close it; we'll re-open it again later if everything's happy.
+#ifndef __MSVCRT__
+   F->fd = open(F->fname, O_RDONLY);
+   // why 3? because 0 is stdin, 1 is stdout, 2 is stderr.  Duh!
+   if (F->fd < 3)
+      RAW_PROFILE_RET_CODE(F, -6, "Cannot open the file.", return F->retval);
+   F->fh = NULL;
+   filesizetotal = lseek(F->fd, 0, SEEK_END);
+   filesizetotal = lseek(F->fd, 0, SEEK_CUR);
+   close(F->fd);
+   F->fd = 0;
+#else
+   F->fh = fopen(F->fname, "rb");
+   if (!F->fh)
+      RAW_PROFILE_RET_CODE(F, -6, "Cannot open the file.", return F->retval);
+   F->fd = 0;
+   fseek(F->fh, 0, SEEK_END);
+   filesizetotal = ftell(F->fh);
+   fclose(F->fh);
+   F->fh = NULL;
+#endif
+
+   F->size = filesizetotal;
+   F->numblocks = filesizetotal/(512+24); // number of sectors in the image; files often have some extra padding at the end, which is unused.
+   F->datasize = 512; // we don't support other sizes
+   F->sectorsize = 512;
+   F->tagsize = 20; // each sector has a 20-byte tag; we don't support other sizes
+   F->datasizetotal = F->numblocks * F->sectorsize;
+   F->tagsizetotal = F->numblocks * F->tagsize;
+
+   fprintf(stderr,"lib_raw_profile_image.c: the file size is %ld bytes; numblocks is %ld.\n", F->size, F->numblocks);
+
+   // We (and the rest of the Lisaem code) don't need/use these:
+   F->dc42seekstart = -1;
+   F->sectoroffset = -1;
+   F->tagstart = -1;
+   F->maxtrk = -1;
+   F->maxsec = -1;
+   F->maxside = -1;
+   F->ftype = -1;
+
+   F->readonly = 0; // read/write by default
+   F->synconwrite = 0; // no sync on write by default
+
+#ifdef HAVE_MMAPEDIO
+   F->mmappedio = 1;
+#else
+   F->mmappedio = 0;
+#endif
+
+   // Parse options for opening image file
+   while (*options)
+   {
+      //{fprintf(stderr,"parsing option %c\n",*options); fflush(stderr);}
+      switch (tolower(*options))
+      {
+      case 'r':
+         F->readonly = 1;
+         break; // r=read only
+      case 'w':
+         F->readonly = 0;
+         break; // w=read/write
+      case 'p':
+         F->readonly = 2;
+         break; // p=private writes (not written back to disk, kept in RAM to fool emulator)
+
+      case 'm': // m=memory mapped I/O if available, else just plain disk I/O
+#ifdef HAVE_MMAPEDIO
+         F->mmappedio = 1;
+#else
+         F->mmappedio = 0;
+#endif
+         break;
+
+      case 'n':
+         F->mmappedio = 0;
+         break; // n=never use mmapped I/O, nor RAM.
+      case 'a':
+         F->mmappedio = 2;
+         break; // a=always in RAM. manage it ourselves, even if we have mmapped I/O available
+      case 'b': // b=best choice (for speed):
+#ifdef HAVE_MMAPEDIO
+         F->mmappedio = 1;
+         break; //   if we have mmapped I/O in the OS, use that.
+#else
+         F->mmappedio = 2;
+                  break; //   otherwise, load the whole image in RAM.
+#endif
+
+      case 's':
+         F->synconwrite = 1;
+         break;
+      default:
+      {
+         int i = strlen(F->returnmsg);
+         if (i < 80)
+         {
+            F->returnmsg[i] = *options;
+            F->returnmsg[i + 1] = 0;
+         }
+      }
+      }
+      options++;
+   }
+
+   if (strlen(F->returnmsg) > 0 && strlen(F->returnmsg) < (80 - 14))
+      strncat(F->returnmsg, " unknown opts", 80);
+
+   if (F->readonly == 0)
+   {
+      // Open the image file in read/write mode
+      if (F->fd > 2)
+         close(F->fd); // close the file and reopen it as possibly writeable
+      if (F->fh)
+         fclose(F->fh);
+
+#ifndef __MSVCRT__
+      F->fd = open(F->fname, O_RDWR);
+      if (F->fd < 3)
+         RAW_PROFILE_RET_CODE(F, -86, "Cannot re-open file for writing", return F->retval);
+      F->fh = NULL;
+#else
+      F->fh = fopen(F->fname, "r+b");
+      if (!F->fh)
+         RAW_PROFILE_RET_CODE(F, -86, "Cannot re-open file for writing", return F->retval);
+      F->fd = 0;
+#endif
+
+#ifdef HAVE_MMAPEDIO
+      if (F->mmappedio)
+      {
+         errno = 0;
+         F->RAM = mmap(0, F->size, PROT_READ | PROT_WRITE, MAP_SHARED, F->fd, 0); // writeable image
+         //{fprintf(stderr,"MMAPped writeable image errno:%d\n",errno); fflush(stderr);}
+      }
+#endif
+   }
+   else
+   {
+      // Open the image file in read-only mode
+#ifdef HAVE_MMAPEDIO
+      if (F->mmappedio)
+      {
+         errno = 0;
+         F->RAM = mmap(0, F->size, PROT_READ | PROT_WRITE, MAP_PRIVATE, F->fd, 0); // read only/private  - fd is already opened rd only
+         //{fprintf(stderr,"MMAPped READ-ONLY/PRIVATE image errno:%d\n",errno); fflush(stderr);}
+      }
+#endif
+   }
+
+   if (F->mmappedio == 0)
+   {
+      // Allocate RAM for just 1 sector's data + tag data (we'll store sector data first, then tag data)
+      F->RAM = malloc((F->tagsize + F->sectorsize)); 
+      fprintf(stderr,"Direct to disk image\n"); fflush(stderr);
+   }
+   if (F->mmappedio == 2) // "2" means "always use RAM, do not use mmapped I/O"
+   {
+      // Allocate as much  RAM as the file size
+      F->RAM = malloc(F->size);
+      if (F->RAM)
+      {
+         int i;
+         if (F->fd > 2)
+         {
+            // Read the file into memory, on non-Windows OS:
+            lseek(F->fd, 0, SEEK_SET);
+            i = read(F->fd, F->RAM, F->size);
+         }
+         if (F->fh)
+         {
+            // Read the file into memory, on Windows:
+            fseek(F->fh, 0, SEEK_SET);
+            i = fread(F->RAM, F->size, 1, F->fh);
+         }
+      }
+   }
+
+   // oops! no ram, or mmap failed.
+   if (!F->RAM || (F->RAM == (void *)(-1)))
+   {
+      if (F->fd > 2)
+      {
+         close(F->fd);
+         F->fd = -1;
+      }
+      if (F->fh)
+      {
+         fclose(F->fh);
+         F->fh = NULL;
+      }
+
+      RAW_PROFILE_RET_CODE(F, -99, "Could not mmap the file or allocate memory", return F->retval);
+   }
+
+   RAW_PROFILE_RET_CODE(F, 0, "Raw Profile image opened", return F->retval);
+   return F->retval; // silence compiler warning about lack of return value
+}

--- a/src/lib/libdc42/tester/src/test-interleave.c
+++ b/src/lib/libdc42/tester/src/test-interleave.c
@@ -11,7 +11,37 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+For sector number  0: interleave(0)=0 
+For sector number  1: interleave(1)=5
+For sector number  2: interleave(2)=10 
+For sector number  3: interleave(3)=15
+For sector number  4: interleave(4)=4
+For sector number  5: interleave(5)=9 
+For sector number  6: interleave(6)=14
+For sector number  7: interleave(7)=3 
+For sector number  8: interleave(8)=8 
+For sector number  9: interleave(9)=13 
+For sector number 10: interleave(10)=2 
+For sector number 11: interleave(11)=7 
+For sector number 12: interleave(12)=12 
+For sector number 13: interleave(13)=1 
+For sector number 14: interleave(14)=6 
+For sector number 15: interleave(15)=11 
+For sector number 16: interleave(16)=16 
+For sector number 17: interleave(17)=21 
+For sector number 18: interleave(18)=26 
+For sector number 19: interleave(19)=31 
+For sector number 20: interleave(20)=20
+... etc ...
+ */
 long interleave5(long sector)
+{
+  static const int offset_delta[] = {0, 4, 8, 12, 0, 4, 8, -4, 0, 4, -8, -4, 0, -12, -8, -4};
+  return sector + offset_delta[(sector & 15)]; // "sector & 15" is an optimized version of "sector % 16"
+}
+
+long interleave5_suboptimal(long sector)
 {
   static const int offset[] = {0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11, 16, 21, 26, 31, 20, 25, 30, 19, 24, 29, 18, 23, 28, 17, 22, 27};
   return offset[sector % 32] + sector - (sector % 32);
@@ -31,6 +61,7 @@ int main(int argc, char *argv[])
   {
     inter = interleave5(i);
     deinter = deinterleave5(inter);
+    fprintf(stdout, "For sector number %ld: interleave5=%ld ; deinterleave5=%ld\n", i, inter, inter, deinter);
     if (i != deinter)
     {
       fprintf(stdout, "interleave failure. deinterleaved5(interleaved(%ld)=%ld)=%ld != %ld\n", i, inter, deinter, i);

--- a/src/tools/src/raw-to-dc42.c
+++ b/src/tools/src/raw-to-dc42.c
@@ -22,19 +22,41 @@ int deinterleave = 0;
 
 // ---------------------------------------------
 
+/**
+For sector number  0: interleave(0)=0 
+For sector number  1: interleave(1)=5
+For sector number  2: interleave(2)=10 
+For sector number  3: interleave(3)=15
+For sector number  4: interleave(4)=4
+For sector number  5: interleave(5)=9 
+For sector number  6: interleave(6)=14
+For sector number  7: interleave(7)=3 
+For sector number  8: interleave(8)=8 
+For sector number  9: interleave(9)=13 
+For sector number 10: interleave(10)=2 
+For sector number 11: interleave(11)=7 
+For sector number 12: interleave(12)=12 
+For sector number 13: interleave(13)=1 
+For sector number 14: interleave(14)=6 
+For sector number 15: interleave(15)=11 
+For sector number 16: interleave(16)=16 
+For sector number 17: interleave(17)=21 
+For sector number 18: interleave(18)=26 
+For sector number 19: interleave(19)=31 
+For sector number 20: interleave(20)=20
+... etc ...
+ */
 long interleave5(long sector)
+{
+  static const int offset_delta[] = {0, 4, 8, 12, 0, 4, 8, -4, 0, 4, -8, -4, 0, -12, -8, -4};
+  return sector + offset_delta[(sector & 15)]; // "sector & 15" is an optimized version of "sector % 16"
+}
+
+long interleave5_suboptimal(long sector)
 {
   static const int offset[] = {0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11, 16, 21, 26, 31, 20, 25, 30, 19, 24, 29, 18, 23, 28, 17, 22, 27};
   return offset[sector & 31] + sector - (sector & 31);
 }
-
-// This is another, simplified way to do the interleaving above (currently unused)
-long interleave5_another_way(int sector)
-{
-	int offset_delta[] = {0, 4, 8, 12, 0, 4, 8, -4, 0, 4, -8, -4, 0, -12, -8, -4};
-	return sector + offset_delta[(sector % 16)];
-}
-
 
 long deinterleave5(long sector)
 {
@@ -213,17 +235,4 @@ int main(int argc, char *argv[])
   puts("                                                               \rDone.");
   fclose(raw);
   return 0;
-}
-
-
-void interleave_deinterleave_test(void)
-{
-  int i;
-  puts("Interleave5 / Deinterleave5 test:");
-  for (i = 0; i < 1000; i++)
-  {
-    long inter = interleave5(i);
-    long deinter = deinterleave5(inter);
-    printf("Sector %3d -> interleave5 -> %3ld -> interleave5-again -> %3ld -> deinterleave5 -> %3ld\n", i, inter, interleave5_another_way(i), deinter);
-  }
 }

--- a/src/tools/src/rraw-to-dc42.c
+++ b/src/tools/src/rraw-to-dc42.c
@@ -22,7 +22,37 @@ int deinterleave = 0;
 
 // ---------------------------------------------
 
+/**
+For sector number  0: interleave(0)=0 
+For sector number  1: interleave(1)=5
+For sector number  2: interleave(2)=10 
+For sector number  3: interleave(3)=15
+For sector number  4: interleave(4)=4
+For sector number  5: interleave(5)=9 
+For sector number  6: interleave(6)=14
+For sector number  7: interleave(7)=3 
+For sector number  8: interleave(8)=8 
+For sector number  9: interleave(9)=13 
+For sector number 10: interleave(10)=2 
+For sector number 11: interleave(11)=7 
+For sector number 12: interleave(12)=12 
+For sector number 13: interleave(13)=1 
+For sector number 14: interleave(14)=6 
+For sector number 15: interleave(15)=11 
+For sector number 16: interleave(16)=16 
+For sector number 17: interleave(17)=21 
+For sector number 18: interleave(18)=26 
+For sector number 19: interleave(19)=31 
+For sector number 20: interleave(20)=20
+... etc ...
+ */
 long interleave5(long sector)
+{
+  static const int offset_delta[] = {0, 4, 8, 12, 0, 4, 8, -4, 0, 4, -8, -4, 0, -12, -8, -4};
+  return sector + offset_delta[(sector & 15)]; // "sector & 15" is an optimized version of "sector % 16"
+}
+
+long interleave5_suboptimal(long sector)
 {
   static const int offset[] = {0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11, 16, 21, 26, 31, 20, 25, 30, 19, 24, 29, 18, 23, 28, 17, 22, 27};
   return offset[sector & 31] + sector - (sector & 31);


### PR DESCRIPTION
Added support for raw Profile image files,  like the ones used by popular hardware emulators:   IDEFile, ESProfile, Cameo/Aphid and probably others.

How it works:
In your File->Preferences, tab "ports", set your profile file path to the desired file that is in raw Profile format.
Ideally, the file extension should be ".image", otherwise you will get a warning at LisaEm startup (which you can avoid by renaming the file to "...image").
The code in profile.c first attempts to open the file as a dc42 file, it finds out that it is not such (the dc42 header is missing), and then it opens it as a raw Profile file.

There is no any conversion going between formats:
if a file is a valid dc42 file, it will be accessed using the code in libdc42.c; otherwise, it will be accessed using the new code in lib_raw_profile_image.c

If you want to install some Lisa OS (e.g. LOS3.0)  on a new raw profile file, do this: Create a new blank file named e.g. lisaem.image (on Linux:  dd if=/dev/zero of=lisaem.image bs=1024 count=5120) with the desired size (for a 5MB Profile it should be 9729 sectors * 532 bytes/sector=5175828 bytes or more); then go ahead, insert the necessary floppies in LisaEm (and boot from the 1st one) to install your desired Lisa OS. Then restart LisaEm to boot from the Profile image. But how would the Lisa installation software know what size disk I want (5 MB vs 10 MB)? The Lisa issues a special command to the Profile to get it's "spare table" and "number of sectors" (hard drive size). The  code calculates the number of sectors from the file size (by dividing it by sector+tag size of 532).

To learn more about the raw profile format, see the comments in src/lib/libdc42/src/lib_raw_profile_image.c
In case you wonder: LisaEm does not cache any pending file writes; they are written to the file immediately (for both raw and dc42 file formats).

I was able to add this feature without touching the existing code in libdc42.c (after I prepared and refactored the code in there in a previous commit).

There was some fishy code in LisaEm that would rename my profile image file every time I change the I/O roms (in the preferences) to/from version "88" (aka Lisa XL); it would replace the string "profile" in the file to "widget". Most people, like me, do not have two different files with different names. So LisaEm would give me a "file not found" error. I deleted that code...

I added a nice feature that shows the total number of floppy and profile sectors read/written, on the status bar at the bottom of the LisaEm window. It is useful when LisaEm appears to be stuck, to see if it has crashed, or is it still reading/writing to/from floppies profile-s.

I did good amount of testing on Linux and Windows, and things compile and work fine. Ready to merge.

