### PR TITLE
Created GitHub Actions for automated continuous builds and on-release builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build wxWidgets
         run: |
-          ./scripts/build-wx3.2.1-gtk.sh
+          ./scripts/build-wx3.2.1-gtk.sh --with-libtiff=builtin
           
       - name: Build LisaEm
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,3 +1,9 @@
+# Generate Linux .AppImage and .deb build artifacts for 64-bit Linux OS.
+# If running a continuous build, skip generating the .deb package, for the follwing reason:
+# The "dpkg" debian package installer compares the version in the .deb package with the currently installed version,
+# to decide if the .deb package is newer or not, and ignores (skips installing) older packages.
+# The continuous builds do not have a good version identifier that would compare well to other builds.
+#
 name: Build and package LisaEm for Linux
 
 on:
@@ -47,14 +53,12 @@ jobs:
           echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
           
       - name: Verify that wxWidgets is available
-        run: |
-          which wx-config
-          wx-config --list
+        run: which wx-config && wx-config --list
 
       - name: Download appimagetool
         run: |
           cd scripts
-          wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          wget https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
           mv appimagetool-x86_64.AppImage appimagetool
           chmod +x appimagetool
           cd ..
@@ -73,20 +77,25 @@ jobs:
         run: |
           # Use the variables passed from the master to name the artifact files
           
-          APPIMAGE_FILENAME="LisaEm-${{ inputs.version_in_file_name }}-Linux_x86_64.AppImage"
-          mv ./pkg/LisaEm_Linux_x86_64.AppImage "$APPIMAGE_FILENAME"
+          APPIMAGE_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-Linux_x86_64.AppImage"
+          mv pkg/LisaEm_Linux_x86_64.AppImage "$APPIMAGE_FILENAME"
 
           # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
           eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
-          DEBPKG_FILENAME="LisaEm-${{ inputs.version_in_file_name }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
-          mv ./pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
+          DEBPKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
+          mv pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
 
           if [[ "${{ inputs.version_id }}" == "continuous-"* ]]; then
             # Include only the .AppImage package (skipping the .deb package) in continuous builds
             echo "ARTIFACT_PATHS=$APPIMAGE_FILENAME" >> $GITHUB_ENV
           else
-            # Include both .AppImage and .deb packages in release builds. The "-*" at the end matches both files
-            echo "ARTIFACT_PATHS=LisaEm-${{ inputs.version_in_file_name }}-*" >> $GITHUB_ENV
+            # Include both .AppImage and .deb packages in release builds
+            {
+              echo "ARTIFACT_PATHS<<EOF"
+              echo "$APPIMAGE_FILENAME"
+              echo "$DEBPKG_FILENAME"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
           fi
           echo "Will upload the following artifacts: ${{ env.ARTIFACT_PATHS }}"
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,39 @@
+name: Build and package LisaEm for Linux
+
+on:
+  workflow_call:
+    inputs:
+      version_id:
+        required: true
+        type: string
+      today:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build wxWidgets
+        run: |
+          ./scripts/build-wx3.2.1-gtk.sh
+          
+      - name: Build LisaEm
+        run: |
+          build.sh clean build
+          
+      - name: Package AppImage
+        run: |
+          # Use the variables passed from the master to name the file
+          FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"
+          mv ./pkg/LisaEm_Linux_x86_64.AppImage "$FILENAME"
+          echo "FINAL_NAME=$FILENAME" >> $GITHUB_ENV
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifact
+          path: ${{ env.FINAL_NAME }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -9,16 +9,19 @@ on:
       today:
         required: true
         type: string
+      version_in_file_name:
+        required: true
+        type: string
 
 jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     steps:
-      # Avoid \r\n line endings
-      - run: git config --global core.autocrlf input
+      - name: Avoid \r\n line endings
+        run: git config --global core.autocrlf input
       
-      - name: Checkout repository
+      - name: Check-out the repository
         uses: actions/checkout@v4
 
       - name: List the checked out LisaEm files (the top folder only)
@@ -65,12 +68,12 @@ jobs:
         run: |
           # Use the variables passed from the master to name the artifact files
           
-          APPIMAGE_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"
+          APPIMAGE_FILENAME="LisaEm-${{ inputs.version_in_file_name }}-Linux_x86_64.AppImage"
           mv ./pkg/LisaEm_Linux_x86_64.AppImage "$APPIMAGE_FILENAME"
 
           # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
           eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
-          DEBPKG_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
+          DEBPKG_FILENAME="LisaEm-${{ inputs.version_in_file_name }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
           mv ./pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
 
           if [[ "${{ inputs.version_id }}" == "continuous-"* ]]; then
@@ -78,7 +81,7 @@ jobs:
             echo "ARTIFACT_PATHS=$APPIMAGE_FILENAME" >> $GITHUB_ENV
           else
             # Include both .AppImage and .deb packages in release builds. The "-*" at the end matches both files
-            echo "ARTIFACT_PATHS=LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-*" >> $GITHUB_ENV
+            echo "ARTIFACT_PATHS=LisaEm-${{ inputs.version_in_file_name }}-*" >> $GITHUB_ENV
           fi
           echo "Will upload the following artifacts: ${{ env.ARTIFACT_PATHS }}"
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install libtiff & libtiff-dev
+      - name: Install libraries that are needed to build wxWidgets
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtiff6 libtiff-dev
+          sudo apt-get install -y libtiff6 libtiff-dev build-essential libgtk-3-dev
           
       - name: Build wxWidgets
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -97,7 +97,6 @@ jobs:
               echo "EOF"
             } >> "$GITHUB_ENV"
           fi
-          echo "Will upload the following artifacts: ${{ env.ARTIFACT_PATHS }}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,17 +10,6 @@ on:
         required: true
         type: string
 
-defaults:
-  run:
-    # "--login" carries over env. variables from one "run" command to the next.
-    # "--norc" means "do not execute ~/.bashrc .
-    # "-eo pipefail" causes the shell to exit immediately if any simple command fails 
-    # (exits with a non-zero status). The exit status of a pipeline
-    # (a sequence of commands connected by |) is:
-    # the status of the rightmost command to exit with a non-zero status, 
-    # or zero if all commands succeed.
-    shell: bash --login --norc -eo pipefail {0}
-
 jobs:
   build:
     # The type of runner that the job will run on

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,27 +10,50 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    # "--login" carries over env. variables from one "run" command to the next.
+    # "--norc" means "do not execute ~/.bashrc .
+    # "-eo pipefail" causes the shell to exit immediately if any simple command fails 
+    # (exits with a non-zero status). The exit status of a pipeline
+    # (a sequence of commands connected by |) is:
+    # the status of the rightmost command to exit with a non-zero status, 
+    # or zero if all commands succeed.
+    shell: bash --login --norc -eo pipefail {0}
+
 jobs:
   build:
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     steps:
+      # Avoid \r\n line endings
+      - run: git config --global core.autocrlf input
+      
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: List the checked out LisaEm files (the top folder only)
+        run: ls -la .
+        
       - name: Install libraries that are needed to build wxWidgets
         run: |
           sudo apt-get update
           sudo apt-get install -y libtiff6 libtiff-dev build-essential libgtk-3-dev
           
-      - name: Build wxWidgets
+      - name: Build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.1-gtk.sh
           
-      - name: Build LisaEm
+      - name: Build and package LisaEm
         run: |
-          build.sh clean build
+          ./build.sh clean build package
+
+      - name: List the generated files
+        run: |
+          ls -l ./bin/lisaem
+          ls -l ./pkg/LisaEm_Linux_x86_64.AppImage
           
-      - name: Package AppImage
+      - name: Rename AppImage file to include version and date
         run: |
           # Use the variables passed from the master to name the file
           FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.1-gtk.sh
+
+      - name: Add wxWidgets to PATH
+        run: echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
           
       - name: Build and package LisaEm
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,17 +25,25 @@ jobs:
         run: ls -la .
         
       - name: Install libraries that are needed to build wxWidgets
+        # Note: "libfuse2" is needed by the appimagetool that packages LisaEm into an .AppImage file
         run: |
           sudo apt-get update
-          sudo apt-get install -y libtiff6 libtiff-dev build-essential libgtk-3-dev
+          sudo apt-get install -y libtiff6 libtiff-dev build-essential libgtk-3-dev libfuse2
           
-      - name: Build and install wxWidgets
+      - name: Download, build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.1-gtk.sh
+          # Add wxWidgets to PATH
+          echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
 
-      - name: Add wxWidgets to PATH
-        run: echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
-          
+      - name: Download appimagetool
+        run: |
+          cd scripts
+          wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          mv appimagetool-x86_64.AppImage appimagetool
+          chmod +x appimagetool
+          cd ..
+
       - name: Build and package LisaEm
         run: |
           ./build.sh clean build package

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         run: |
           echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
-          echo "Exported environment variable VER=$VER"
+          echo "Exported environment variable VER=${{ inputs.version_id }}"
           echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
-          echo "Exported environment variable RELEASEDATE=$RELEASEDATE"
+          echo "Exported environment variable RELEASEDATE=${{ inputs.today }}"
         
       - name: Install libraries that are needed to build wxWidgets
         # Note: "libfuse2" below is needed by the appimagetool that packages LisaEm into an .AppImage file

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,9 +17,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install libtiff & libtiff-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtiff6 libtiff-dev
+          
       - name: Build wxWidgets
         run: |
-          ./scripts/build-wx3.2.1-gtk.sh --with-libtiff=builtin
+          ./scripts/build-wx3.2.1-gtk.sh
           
       - name: Build LisaEm
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -55,29 +55,35 @@ jobs:
         run: |
           ./build.sh clean build package
 
-      - name: List the generated files
+      - name: List the generated artifacts
         run: |
           ls -l ./bin/lisaem
           ls -l ./pkg/LisaEm_Linux_x86_64.AppImage
+          ls -l ./pkg/LisaEm_amd64.deb
           
-      - name: Rename AppImage file to include version and date
+      - name: Rename artifact files to include version and date
         run: |
           # Use the variables passed from the master to name the artifact files
           
           APPIMAGE_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"
           mv ./pkg/LisaEm_Linux_x86_64.AppImage "$APPIMAGE_FILENAME"
-          echo "APPIMAGE_FILENAME=$APPIMAGE_FILENAME" >> $GITHUB_ENV
 
           # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
           eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
           DEBPKG_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
           mv ./pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
-          echo "DEBPKG_FILENAME=$DEBPKG_FILENAME" >> $GITHUB_ENV
+
+          if [[ "${{ inputs.version_id }}" == "continuous-"* ]]; then
+            # Include only the .AppImage package (skipping the .deb package) in continuous builds
+            echo "ARTIFACT_PATHS=$APPIMAGE_FILENAME" >> $GITHUB_ENV
+          else
+            # Include both .AppImage and .deb packages in release builds. The "-*" at the end matches both files
+            echo "ARTIFACT_PATHS=LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-*" >> $GITHUB_ENV
+          fi
+          echo "Will upload the following artifacts: ${{ env.ARTIFACT_PATHS }}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-artifact
-          path: |
-            ${{ env.APPIMAGE_FILENAME }}
-            ${{ env.DEBPKG_FILENAME }}
+          path: ${{ env.ARTIFACT_PATHS }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,6 +23,12 @@ jobs:
 
       - name: List the checked out LisaEm files (the top folder only)
         run: ls -la .
+
+      - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
+          echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
+          echo "Exported environment variable VER=$VER"
+          echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
+          echo "Exported environment variable RELEASEDATE=$RELEASEDATE"
         
       - name: Install libraries that are needed to build wxWidgets
         # Note: "libfuse2" is needed by the appimagetool that packages LisaEm into an .AppImage file

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,13 +25,14 @@ jobs:
         run: ls -la .
 
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
+        run: |
           echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
           echo "Exported environment variable VER=$VER"
           echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
           echo "Exported environment variable RELEASEDATE=$RELEASEDATE"
         
       - name: Install libraries that are needed to build wxWidgets
-        # Note: "libfuse2" is needed by the appimagetool that packages LisaEm into an .AppImage file
+        # Note: "libfuse2" below is needed by the appimagetool that packages LisaEm into an .AppImage file
         run: |
           sudo apt-get update
           sudo apt-get install -y libtiff6 libtiff-dev build-essential libgtk-3-dev libfuse2
@@ -61,13 +62,22 @@ jobs:
           
       - name: Rename AppImage file to include version and date
         run: |
-          # Use the variables passed from the master to name the file
-          FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"
-          mv ./pkg/LisaEm_Linux_x86_64.AppImage "$FILENAME"
-          echo "FINAL_NAME=$FILENAME" >> $GITHUB_ENV
+          # Use the variables passed from the master to name the artifact files
+          
+          APPIMAGE_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Linux_x86_64.AppImage"
+          mv ./pkg/LisaEm_Linux_x86_64.AppImage "$APPIMAGE_FILENAME"
+          echo "APPIMAGE_FILENAME=$APPIMAGE_FILENAME" >> $GITHUB_ENV
+
+          # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
+          eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
+          DEBPKG_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
+          mv ./pkg/LisaEm-ubuntu-${OSREL_VERSION_ID}-amd64.deb "$DEBPKG_FILENAME"
+          echo "DEBPKG_FILENAME=$DEBPKG_FILENAME" >> $GITHUB_ENV
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-artifact
-          path: ${{ env.FINAL_NAME }}
+          path: |
+            ${{ env.APPIMAGE_FILENAME }}
+            ${{ env.DEBPKG_FILENAME }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,6 +45,11 @@ jobs:
           ./scripts/build-wx3.2.1-gtk.sh
           # Add wxWidgets to PATH
           echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
+          
+      - name: Verify that wxWidgets is available
+        run: |
+          which wx-config
+          wx-config --list
 
       - name: Download appimagetool
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -71,7 +71,7 @@ jobs:
           # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
           eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
           DEBPKG_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
-          mv ./pkg/LisaEm-ubuntu-${OSREL_VERSION_ID}-amd64.deb "$DEBPKG_FILENAME"
+          mv ./pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
           echo "DEBPKG_FILENAME=$DEBPKG_FILENAME" >> $GITHUB_ENV
 
       - name: Upload Artifact

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,8 +1,8 @@
 # Generate Linux .AppImage and .deb build artifacts for 64-bit Linux OS.
-# If running a continuous build, skip generating the .deb package, for the follwing reason:
+# When running a continuous build, skip generating the .deb package, for the following reason:
 # The "dpkg" debian package installer compares the version in the .deb package with the currently installed version,
 # to decide if the .deb package is newer or not, and ignores (skips installing) older packages.
-# The continuous builds do not have a good version identifier that would compare well to other builds.
+# The continuous builds don't have a good version identifier that would compare well to other (continuous and release) builds.
 #
 name: Build and package LisaEm for Linux
 
@@ -82,7 +82,7 @@ jobs:
 
           # Parse the ubuntu version (e.g. 24.04) into an env var OSREL_VERSION_ID
           eval $(sed -e 's/^/export OSREL_/g' /etc/os-release )
-          DEBPKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-ubuntu-${OSREL_VERSION_ID}-amd64.deb"
+          DEBPKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-Ubuntu-${OSREL_VERSION_ID}_amd64.deb"
           mv pkg/LisaEm_amd64.deb "$DEBPKG_FILENAME"
 
           if [[ "${{ inputs.version_id }}" == "continuous-"* ]]; then

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,11 +32,14 @@ jobs:
       - name: Download, build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.9-modern-macosx.sh
-          ls -l /usr/local/wx3.2.9-cocoa-macOS-*
+          ls -l /usr/local/wx3.2.9-cocoa-macOS-15.7-x86_64,arm64/bin
+          echo " testing: $(sw_vers -productVersion | cut -d. -f1-2)"
           # Add wxWidgets to PATH
           echo "/usr/local/wx3.2.9-cocoa-macOS-$(sw_vers -productVersion | cut -d. -f1-2)-x86_64,arm64/bin" >> $GITHUB_PATH
-          # Verify that wxWidgets is available
-          wx-config --list
+          # echo "/usr/local/wx3.2.9-cocoa-macOS-15.7-x86_64,arm64/bin" >> $GITHUB_PATH
+
+      - name: Verify that wxWidgets is available
+        run: wx-config --list
           
       - name: Build and package LisaEm
         run: ./build.sh clean build package

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Download, build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.9-modern-macosx.sh
+          ls -l /usr/local/wx3.2.9-cocoa-macOS-*
           # Add wxWidgets to PATH
-          # echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
+          echo "/usr/local/wx3.2.9-cocoa-macOS-$(sw_vers -productVersion | cut -d. -f1-2)-x86_64,arm64/bin" >> $GITHUB_PATH
+          # Verify that wxWidgets is available
+          wx-config --list
           
       - name: Build and package LisaEm
         run: ./build.sh clean build package

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,9 +47,16 @@ jobs:
       - name: List the generated artifacts
         run: ls -la ./bin && ls -la ./pkg
 
+      - name: Rename artifact file to include version and date
+        run: |
+          MACOS_VERSION = "$(sw_vers -productVersion | cut -d. -f1-2)"
+          MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-$MACOS_VERSION-arm64.pkg"
+          mv pkg/lisaem-macos-$MACOS_VERSION-arm64.pkg $MACOS_PKG_FILENAME
+          echo "ARTIFACT_PATHS=$MACOS_PKG_FILENAME" >> $GITHUB_ENV
+          
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact
-          path: LisaEm-macOS_x86_64.dmg
+          path: ${{ env.ARTIFACT_PATHS }}
   

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Rename the artifact file to include version and date
         run: |
           MACOS_VERSION="$(sw_vers -productVersion | cut -d. -f1-2)"
-          MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-$MACOS_VERSION-arm64.pkg"
+          MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-MacOS-$MACOS_VERSION_arm64.pkg"
           mv pkg/lisaem-macos-$MACOS_VERSION-arm64.pkg $MACOS_PKG_FILENAME
           echo "ARTIFACT_PATHS=$MACOS_PKG_FILENAME" >> $GITHUB_ENV
           

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -50,13 +50,13 @@ jobs:
       - name: Rename the artifact file to include version and date
         run: |
           MACOS_VERSION="$(sw_vers -productVersion | cut -d. -f1-2)"
-          MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-MacOS-$MACOS_VERSION_arm64.pkg"
-          mv pkg/lisaem-macos-$MACOS_VERSION-arm64.pkg $MACOS_PKG_FILENAME
-          echo "ARTIFACT_PATHS=$MACOS_PKG_FILENAME" >> $GITHUB_ENV
+          MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-MacOS-${MACOS_VERSION}_arm64.pkg"
+          mv pkg/lisaem-macos-${MACOS_VERSION}-arm64.pkg $MACOS_PKG_FILENAME
+          echo "ARTIFACT_PATH=$MACOS_PKG_FILENAME" >> $GITHUB_ENV
           
-      - name: Upload artifact file
+      - name: Upload the artifact file
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact
-          path: ${{ env.ARTIFACT_PATHS }}
+          path: ${{ env.ARTIFACT_PATH }}
   

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,49 @@
+name: Build and package LisaEm for MacOS
+
+on:
+  workflow_call:
+    inputs:
+      version_id:
+        required: true
+        type: string
+      today:
+        required: true
+        type: string
+      version_in_file_name:
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Check-out the repository
+        uses: actions/checkout@v4
+
+      - name: List the checked out LisaEm files (the top folder only)
+        run: ls -la .
+
+      - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
+        run: |
+          echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
+          echo "Exported environment variable VER=${{ inputs.version_id }}"
+          echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
+          echo "Exported environment variable RELEASEDATE=${{ inputs.today }}"
+
+      - name: Download, build and install wxWidgets
+        run: |
+          ./scripts/build-wx3.2.9-modern-macosx.sh
+          # Add wxWidgets to PATH
+          # echo "/usr/local/wx3.2.1-gtk/bin" >> $GITHUB_PATH
+          
+      - name: Build and package LisaEm
+        run: ./build.sh clean build package
+
+      - name: List the generated artifacts
+        run: ls -l ./bin/lisaem && ls -l ./pkg
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-artifact
+          path: LisaEm-macOS_x86_64.dmg
+  

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,20 +32,20 @@ jobs:
       - name: Download, build and install wxWidgets
         run: |
           ./scripts/build-wx3.2.9-modern-macosx.sh
-          ls -l /usr/local/wx3.2.9-cocoa-macOS-15.7-x86_64,arm64/bin
-          echo " testing: $(sw_vers -productVersion | cut -d. -f1-2)"
-          # Add wxWidgets to PATH
+          # Add wxWidgets to PATH. Sample location: "/usr/local/wx3.2.9-cocoa-macOS-15.7-x86_64,arm64/bin"
           echo "/usr/local/wx3.2.9-cocoa-macOS-$(sw_vers -productVersion | cut -d. -f1-2)-x86_64,arm64/bin" >> $GITHUB_PATH
-          # echo "/usr/local/wx3.2.9-cocoa-macOS-15.7-x86_64,arm64/bin" >> $GITHUB_PATH
 
       - name: Verify that wxWidgets is available
-        run: wx-config --list
+        run: |
+          echo " The MacOS version is: $(sw_vers -productVersion | cut -d. -f1-2)"
+          which wx-config
+          wx-config --list
           
       - name: Build and package LisaEm
         run: ./build.sh clean build package
 
       - name: List the generated artifacts
-        run: ls -l ./bin/lisaem && ls -l ./pkg
+        run: ls -la ./bin && ls -la ./pkg
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,14 +47,14 @@ jobs:
       - name: List the generated artifacts
         run: ls -la ./bin && ls -la ./pkg
 
-      - name: Rename artifact file to include version and date
+      - name: Rename the artifact file to include version and date
         run: |
-          MACOS_VERSION = "$(sw_vers -productVersion | cut -d. -f1-2)"
+          MACOS_VERSION="$(sw_vers -productVersion | cut -d. -f1-2)"
           MACOS_PKG_FILENAME="pkg/LisaEm-${{ inputs.version_in_file_name }}-$MACOS_VERSION-arm64.pkg"
           mv pkg/lisaem-macos-$MACOS_VERSION-arm64.pkg $MACOS_PKG_FILENAME
           echo "ARTIFACT_PATHS=$MACOS_PKG_FILENAME" >> $GITHUB_ENV
           
-      - name: Upload Artifact
+      - name: Upload artifact file
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -65,8 +65,16 @@ jobs:
       - name: List the generated artifacts
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
 
+      - name: Rename artifact file to include version and date
+        run: |
+          # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
+          ARTIFACT_FILENAME="pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+          mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
+          echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> $GITHUB_ENV
+          echo "Will upload the following artifacts: ${{ env.ARTIFACT_FILENAME }}"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          path: pkg/LisaEm-win-x86_64.zip
+          path: ${{ env.ARTIFACT_FILENAME }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,9 +55,9 @@ jobs:
       # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         run: |
-          echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
+          echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Exported environment variable VER=${{ inputs.version_id }}"
-          echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
+          echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Exported environment variable RELEASEDATE=${{ inputs.today }}"
 
       - name: Build LisaEm
@@ -71,7 +71,7 @@ jobs:
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
           ARTIFACT_FILENAME="pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
           mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
-          echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> $GITHUB_ENV
+          echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
           ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,8 +55,6 @@ jobs:
       # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         run: |
-          # Tell Cygwin's bash to ignore \r\n in the scriptlet below
-          set -o igncr
           echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Exported environment variable VER=${{ inputs.version_id }}"
           echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
@@ -70,11 +68,9 @@ jobs:
 
       - name: Rename artifact file to include version and date
         run: |
-          # Tell Cygwin's bash to ignore \r\n in the scriptlet below
-          set -o igncr
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
           # and copy it into folder ${{ github.workspace }} 
-          ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+          ARTIFACT_FILENAME=$(echo "LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip" | tr -d '\r')
           cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
           pwd && echo "${{ github.workspace }}" && ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -71,13 +71,13 @@ jobs:
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
           # and copy it into the curtrent folder, which is ${{ github.workspace }} 
           ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
-          cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "./$ARTIFACT_FILENAME"
+          cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
-          pwd && echo "${{ github.workspace }}" && ls -l "./$ARTIFACT_FILENAME"
+          pwd && echo "${{ github.workspace }}" && ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: ${{ github.workspace }}/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip
+          path: ${{ github.workspace }}\LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -75,9 +75,16 @@ jobs:
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
           pwd && echo "${{ github.workspace }}" && ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 
+          # Export to environment variable for the next step
+          # Try later: echo "FINAL_ZIP=$ARTIFACT_FILENAME" >> $GITHUB_ENV
+
+      - name: Verify artifact file exists using Windows-native cmd
+        run: dir "${{ github.workspace }}"
+        shell: cmd
+        
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: ${{ github.workspace }}\LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip
+          path: "**/*.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,6 +55,8 @@ jobs:
       # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         run: |
+          # Tell Cygwin's bash to ignore \r\n in the scriptlet below
+          set -o igncr
           echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Exported environment variable VER=${{ inputs.version_id }}"
           echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
@@ -68,8 +70,9 @@ jobs:
 
       - name: Rename artifact file to include version and date
         run: |
+          # Tell Cygwin's bash to ignore \r\n in the scriptlet below
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
-          # and copy it into the curtrent folder, which is ${{ github.workspace }} 
+          # and copy it into folder ${{ github.workspace }} 
           ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
           cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
@@ -83,5 +86,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: "**/*.zip"
+          # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the file name below
+          path: "LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -73,7 +73,7 @@ jobs:
           mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
           echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> $GITHUB_ENV
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
-          ls -l $ARTIFACT_FILENAME
+          ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-name: Build and package LisaEm for Linux
+name: Build and package LisaEm for Windows
 
 on:
   workflow_call:
@@ -30,21 +30,18 @@ jobs:
       # Avoid \r\n line endings
       - run: git config --global core.autocrlf input
 
-      # Checks-out my repository under $GITHUB_WORKSPACE, so your job can access it
+      # Check-out the repository into folder ${{ github.workspace }}
       - uses: actions/checkout@v4
 
-      # Installs the latest Cygwin with default packages
+      # Installs the latest Cygwin
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@master
         with:
-          # Provide a space-separated or comma-separated list of packages to install
+          # Provide a list of Cygwin packages to install
           packages: mingw64-x86_64-gcc-core mingw64-x86_64-gcc-debug-info mingw64-x86_64-gcc-g++ mingw64-x86_64-gcc-objc gcc-core gcc-g++ make zip
 
       - name: Run a simple echo command in Cygwin to test the installation
-        run: echo "Cygwin is installed!"
-
-      - name: Print the installed Cygwin version
-        run: cygcheck -c cygwin
+        run: echo "Cygwin $(cygcheck -c cygwin) is installed!"
 
       - name: List the checked out LisaEm files (the top folder only)
         run: ls -la "$(cygpath '${{ github.workspace }}')"
@@ -52,9 +49,9 @@ jobs:
       - name: Download WxWidgets from the web and build it
         run: cd "$(cygpath '${{ github.workspace }}')/scripts" && ./build-wx3.2.7-cygwin-windows.sh
 
-      # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
-        run: echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV && echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
+        # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
+        run: echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")" && echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
 
       - name: Build LisaEm
         run: cd "$(cygpath '${{ github.workspace }}')" && ./build.sh clean build package
@@ -65,8 +62,8 @@ jobs:
       - name: Rename artifact file to include version and date
         run: mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
 
-      - name: Verify artifact file exists using Windows-native cmd
-        run: dir "${{ github.workspace }}"
+      - name: Print artifact file name using Windows-native cmd
+        run: dir "${{ github.workspace }}\pkg"
         shell: cmd
         
       - name: Upload Artifact

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Download WxWidgets from the web and build it
         run: cd "$(cygpath '${{ github.workspace }}')/scripts" && ./build-wx3.2.7-cygwin-windows.sh
 
+      # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         run: |
           echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
@@ -71,7 +72,8 @@ jobs:
           ARTIFACT_FILENAME="pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
           mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
           echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> $GITHUB_ENV
-          echo "Will upload the following artifacts: ${{ env.ARTIFACT_FILENAME }}"
+          echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
+          ls -l $ARTIFACT_FILENAME
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -69,4 +69,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          path: "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip"
+          path: pkg/LisaEm-win-x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,11 +54,7 @@ jobs:
 
       # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
-        run: |
-          echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")"
-          echo "Exported environment variable VER=${{ inputs.version_id }}"
-          echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
-          echo "Exported environment variable RELEASEDATE=${{ inputs.today }}"
+        run: echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV && echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
 
       - name: Build LisaEm
         run: cd "$(cygpath '${{ github.workspace }}')" && ./build.sh clean build package
@@ -67,7 +63,7 @@ jobs:
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
 
       - name: Rename artifact file to include version and date
-        run: cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+        run: mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
 
       - name: Verify artifact file exists using Windows-native cmd
         run: dir "${{ github.workspace }}"
@@ -77,5 +73,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the file name below
-          path: "LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+          path: "pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -71,7 +71,6 @@ jobs:
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
           ARTIFACT_FILENAME="pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
           mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
-          echo "ARTIFACT_FILENAME=$ARTIFACT_FILENAME" >> "$(cygpath -u "$GITHUB_ENV")"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
           ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 
@@ -79,4 +78,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          path: ${{ env.ARTIFACT_FILENAME }}
+          # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
+          path: pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip
+          path: $(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,7 +38,7 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
           # Provide a space-separated or comma-separated list of packages to install
-          packages: mingw64-x86_64-gcc-core mingw64-x86_64-gcc-debug-info mingw64-x86_64-gcc-g++ mingw64-x86_64-gcc-objc gcc-core gcc-g++ make
+          packages: mingw64-x86_64-gcc-core mingw64-x86_64-gcc-debug-info mingw64-x86_64-gcc-g++ mingw64-x86_64-gcc-objc gcc-core gcc-g++ make zip
 
       - name: Run a simple echo command in Cygwin to test the installation
         run: echo "Cygwin is installed!"
@@ -62,5 +62,11 @@ jobs:
       - name: Build LisaEm
         run: cd "$(cygpath '${{ github.workspace }}')" && ./build.sh clean build package
 
-      - name: List the produced executable lisaem.exe
+      - name: List the generated artifacts
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifact
+          path: "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,24 +51,27 @@ jobs:
       - name: Download WxWidgets from the web and build it
         run: cd "$(cygpath '${{ github.workspace }}')/scripts" && ./build-wx3.2.7-cygwin-windows.sh
 
+      - name: Verify that wxWidgets is available
+        run: which wx-config && wx-config --list
+
       - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
         # The VER and RELEASEDATE environment variables will appear in the Help->About LisaEm menu.
         run: echo "VER=${{ inputs.version_id }}" >> "$(cygpath -u "$GITHUB_ENV")" && echo "RELEASEDATE=${{ inputs.today }}" >> "$(cygpath -u "$GITHUB_ENV")"
 
-      - name: Build LisaEm
+      - name: Build and package LisaEm
         run: cd "$(cygpath '${{ github.workspace }}')" && ./build.sh clean build package
 
       - name: List the generated artifacts
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
 
-      - name: Rename artifact file to include version and date
+      - name: Rename the artifact file to include version and date
         run: mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_in_file_name }}-Windows_x86_64.zip"
 
-      - name: Print artifact file name using Windows-native cmd
+      - name: Print the artifact file name using Windows-native cmd
         run: dir "${{ github.workspace }}\pkg"
         shell: cmd
         
-      - name: Upload Artifact
+      - name: Upload the artifact file
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,6 +9,9 @@ on:
       today:
         required: true
         type: string
+      version_in_file_name:
+        required: true
+        type: string
 
 defaults:
   run:
@@ -27,13 +30,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      # Avoid \r\n line endings
-      - run: git config --global core.autocrlf input
+      - name: Avoid \r\n line endings
+        run: git config --global core.autocrlf input
 
-      # Check-out the repository into folder ${{ github.workspace }}
-      - uses: actions/checkout@v4
+      - name: Check-out the repository
+        uses: actions/checkout@v4
 
-      # Installs the latest Cygwin
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@master
         with:
@@ -60,7 +62,7 @@ jobs:
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
 
       - name: Rename artifact file to include version and date
-        run: mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+        run: mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_in_file_name }}-Windows_x86_64.zip"
 
       - name: Print artifact file name using Windows-native cmd
         run: dir "${{ github.workspace }}\pkg"
@@ -70,4 +72,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
-          path: "pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+          path: "pkg/LisaEm-${{ inputs.version_in_file_name }}-Windows_x86_64.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -69,14 +69,14 @@ jobs:
       - name: Rename artifact file to include version and date
         run: |
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
-          ARTIFACT_FILENAME="pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
-          mv "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
+          ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
+          cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "./$ARTIFACT_FILENAME"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
-          ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
+          ls -l "./$ARTIFACT_FILENAME"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: pkg/LisaEm-*-Windows_x86_64.zip
+          path: LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Rename artifact file to include version and date
         run: |
           # Tell Cygwin's bash to ignore \r\n in the scriptlet below
+          set -o igncr
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
           # and copy it into folder ${{ github.workspace }} 
           ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,66 @@
+name: Build and package LisaEm for Linux
+
+on:
+  workflow_call:
+    inputs:
+      version_id:
+        required: true
+        type: string
+      today:
+        required: true
+        type: string
+
+defaults:
+  run:
+    # "--login" carries over env. variables from one "run" command to the next.
+    # "--norc" means "do not execute ~/.bashrc .
+    # "-eo pipefail" causes the shell to exit immediately if any simple command fails 
+    # (exits with a non-zero status). The exit status of a pipeline
+    # (a sequence of commands connected by |) is:
+    # the status of the rightmost command to exit with a non-zero status, 
+    # or zero if all commands succeed.
+    shell: bash --login --norc -eo pipefail {0}
+
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    steps:
+      # Avoid \r\n line endings
+      - run: git config --global core.autocrlf input
+
+      # Checks-out my repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Installs the latest Cygwin with default packages
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@master
+        with:
+          # Provide a space-separated or comma-separated list of packages to install
+          packages: mingw64-x86_64-gcc-core mingw64-x86_64-gcc-debug-info mingw64-x86_64-gcc-g++ mingw64-x86_64-gcc-objc gcc-core gcc-g++ make
+
+      - name: Run a simple echo command in Cygwin to test the installation
+        run: echo "Cygwin is installed!"
+
+      - name: Print the installed Cygwin version
+        run: cygcheck -c cygwin
+
+      - name: List the checked out LisaEm files (the top folder only)
+        run: ls -la "$(cygpath '${{ github.workspace }}')"
+
+      - name: Download WxWidgets from the web and build it
+        run: cd "$(cygpath '${{ github.workspace }}')/scripts" && ./build-wx3.2.7-cygwin-windows.sh
+
+      - name: Setup the VER and RELEASEDATE environment variables, to be used by the LisaEm build script
+        run: |
+          echo "VER=${{ inputs.version_id }}" >> $GITHUB_ENV
+          echo "Exported environment variable VER=${{ inputs.version_id }}"
+          echo "RELEASEDATE=${{ inputs.today }}" >> $GITHUB_ENV
+          echo "Exported environment variable RELEASEDATE=${{ inputs.today }}"
+
+      - name: Build LisaEm
+        run: cd "$(cygpath '${{ github.workspace }}')" && ./build.sh clean build package
+
+      - name: List the produced executable lisaem.exe
+        run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -69,14 +69,15 @@ jobs:
       - name: Rename artifact file to include version and date
         run: |
           # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
+          # and copy it into the curtrent folder, which is ${{ github.workspace }} 
           ARTIFACT_FILENAME="LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
           cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "./$ARTIFACT_FILENAME"
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
-          ls -l "./$ARTIFACT_FILENAME"
+          pwd && echo "${{ github.workspace }}" && ls -l "./$ARTIFACT_FILENAME"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip
+          path: ${{ github.workspace }}/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -67,13 +67,7 @@ jobs:
         run: ls -l "$(cygpath '${{ github.workspace }}')/bin/lisaem.exe" && ls -l "$(cygpath '${{ github.workspace }}')/pkg"
 
       - name: Rename artifact file to include version and date
-        run: |
-          # Use the variables passed from the master workflow to rename the artifact file LisaEm-win-x86_64.zip
-          # and copy it into folder ${{ github.workspace }} 
-          ARTIFACT_FILENAME=$(echo "LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip" | tr -d '\r')
-          cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
-          echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
-          pwd && echo "${{ github.workspace }}" && ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
+        run: cp "$(cygpath '${{ github.workspace }}')/pkg/LisaEm-win-x86_64.zip" "$(cygpath '${{ github.workspace }}')/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip"
 
       - name: Verify artifact file exists using Windows-native cmd
         run: dir "${{ github.workspace }}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           name: windows-artifact
           # It's tricky to use the ARTIFACT_FILENAME environment variable here, so we are constructing the path again below
-          path: $(cygpath '${{ github.workspace }}')/pkg/LisaEm-${{ inputs.version_id }}-${{ inputs.today }}-Windows_x86_64.zip
+          path: pkg/LisaEm-*-Windows_x86_64.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -75,9 +75,6 @@ jobs:
           echo "Will upload the following artifacts: $ARTIFACT_FILENAME"
           pwd && echo "${{ github.workspace }}" && ls -l "$(cygpath '${{ github.workspace }}')/$ARTIFACT_FILENAME"
 
-          # Export to environment variable for the next step
-          # Try later: echo "FINAL_ZIP=$ARTIFACT_FILENAME" >> $GITHUB_ENV
-
       - name: Verify artifact file exists using Windows-native cmd
         run: dir "${{ github.workspace }}"
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "version_id=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
-            A continuous build. Use the commit id. Example: version_id=continuous-3e51852
+            # A continuous build. Use the commit id. Example: version_id=continuous-3e51852
             echo "version_id=continuous-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     outputs:
       version_id: ${{ steps.vars.outputs.version_id }}
       today: ${{ steps.vars.outputs.today }}
+      # The version in the file name will start with today's date for continuous builds, so that they will be ordered nicely chronologically in the release page
+      version_in_file_name: ${{ steps.vars.outputs.version_in_file_name }}
     steps:
       - name: Set Variables
         id: vars
@@ -20,14 +22,19 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: |
           # Get Today's Date
-          echo "today=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
+          TODAY=$(date +'%Y.%m.%d')
+          echo "today=$TODAY" >> $GITHUB_OUTPUT
           
           # Check if this is a release or a push
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "version_id=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            VERSION_ID="${{ github.event.release.tag_name }}"
+            echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
+            echo "version_in_file_name=$VERSION_ID-$TODAY" >> $GITHUB_OUTPUT
           else
             # A continuous build. Use the commit id. Example: version_id=continuous-3e51852
-            echo "version_id=continuous-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+            VERSION_ID="continuous-${GITHUB_SHA::7}"
+            echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
+            echo "version_in_file_name=$TODAY-$VERSION_ID" >> $GITHUB_OUTPUT
           fi
 
   # Call the Child Workflows
@@ -44,6 +51,7 @@ jobs:
     with:
       version_id: ${{ needs.setup.outputs.version_id }}
       today: ${{ needs.setup.outputs.today }}
+      version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
       
   # Final job to collect artifacts and post to the release page
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,25 +40,25 @@ jobs:
           fi
 
   # Call the Child Workflows
-  # build-linux:
-  #   needs: setup
-  #   uses: ./.github/workflows/build-linux.yml
-  #   with:
-  #     version_id: ${{ needs.setup.outputs.version_id }}
-  #     today: ${{ needs.setup.outputs.today }}
-  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
-
-  build-windows:
+  build-linux:
     needs: setup
-    uses: ./.github/workflows/build-windows.yml
+    uses: ./.github/workflows/build-linux.yml
     with:
       version_id: ${{ needs.setup.outputs.version_id }}
       today: ${{ needs.setup.outputs.today }}
       version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
+
+  # build-windows:
+  #   needs: setup
+  #   uses: ./.github/workflows/build-windows.yml
+  #   with:
+  #     version_id: ${{ needs.setup.outputs.version_id }}
+  #     today: ${{ needs.setup.outputs.today }}
+  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
       
   # Final job to collect artifacts and post to the release page
   publish:
-    needs: [setup, build-windows]
+    needs: [setup, build-linux]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'push'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,22 @@ jobs:
           fi
 
   # Call the Child Workflows
-  # build-linux:
-  #   needs: setup
-  #   uses: ./.github/workflows/build-linux.yml
-  #   with:
-  #     version_id: ${{ needs.setup.outputs.version_id }}
-  #     today: ${{ needs.setup.outputs.today }}
-  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
+  
+  build-linux:
+    needs: setup
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      version_id: ${{ needs.setup.outputs.version_id }}
+      today: ${{ needs.setup.outputs.today }}
+      version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
 
-  # build-windows:
-  #   needs: setup
-  #   uses: ./.github/workflows/build-windows.yml
-  #   with:
-  #     version_id: ${{ needs.setup.outputs.version_id }}
-  #     today: ${{ needs.setup.outputs.today }}
-  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
+  build-windows:
+    needs: setup
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version_id: ${{ needs.setup.outputs.version_id }}
+      today: ${{ needs.setup.outputs.today }}
+      version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
 
   build-macos:
     needs: setup
@@ -66,7 +67,7 @@ jobs:
       
   # Final job to collect artifacts and post to the release page
   publish:
-    needs: [setup, build-macos]
+    needs: [setup, build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'push'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Set Variables
         id: vars
+        env:
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           # Get Today's Date
           echo "today=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
@@ -24,7 +26,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "version_id=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
-            echo "version_id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            echo "version_id=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
   # Call the Child Workflows
@@ -39,7 +41,7 @@ jobs:
   publish:
     needs: [setup, build-linux]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'push'
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -47,8 +49,12 @@ jobs:
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'push' && 'continuous' || github.event.release.tag_name }}
+          name: ${{ github.event_name == 'push' && 'Continuous Build' || github.event.release.name }}
+          prerelease: ${{ github.event_name == 'push' || github.event.release.prerelease == true }}
           files: |
             **/*.deb
             **/*.AppImage
             **/*.exe
             **/*.dmg
+            **/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,13 @@ jobs:
           fi
 
   # Call the Child Workflows
-  build-linux:
-    needs: setup
-    uses: ./.github/workflows/build-linux.yml
-    with:
-      version_id: ${{ needs.setup.outputs.version_id }}
-      today: ${{ needs.setup.outputs.today }}
-      version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
+  # build-linux:
+  #   needs: setup
+  #   uses: ./.github/workflows/build-linux.yml
+  #   with:
+  #     version_id: ${{ needs.setup.outputs.version_id }}
+  #     today: ${{ needs.setup.outputs.today }}
+  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
 
   # build-windows:
   #   needs: setup
@@ -55,10 +55,18 @@ jobs:
   #     version_id: ${{ needs.setup.outputs.version_id }}
   #     today: ${{ needs.setup.outputs.today }}
   #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
+
+  build-macos:
+    needs: setup
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      version_id: ${{ needs.setup.outputs.version_id }}
+      today: ${{ needs.setup.outputs.today }}
+      version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
       
   # Final job to collect artifacts and post to the release page
   publish:
-    needs: [setup, build-linux]
+    needs: [setup, build-macos]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'push'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Master Release Workflow
+
+on:
+  push:
+    branches: [ main, master ]
+  release:
+    types: [ published ]
+
+jobs:
+  # Logic to determine if we use the Release Tag or the Commit ID as the produced build number
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version_id: ${{ steps.vars.outputs.version_id }}
+      today: ${{ steps.vars.outputs.today }}
+    steps:
+      - name: Set Variables
+        id: vars
+        run: |
+          # Get Today's Date
+          echo "today=$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
+          
+          # Check if this is a release or a push
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "version_id=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "version_id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          fi
+
+  # Call the Child Workflows
+  build-linux:
+    needs: setup
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      version_id: ${{ needs.setup.outputs.version_id }}
+      today: ${{ needs.setup.outputs.today }}
+
+  # Final job to collect artifacts and post to the release page
+  publish:
+    needs: [setup, build-linux]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+      
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            **/*.deb
+            **/*.AppImage
+            **/*.exe
+            **/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "version_id=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
-            echo "version_id=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+            A continuous build. Use the commit id. Example: version_id=continuous-3e51852
+            echo "version_id=continuous-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
   # Call the Child Workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,23 @@ jobs:
           fi
 
   # Call the Child Workflows
-  build-linux:
+  # build-linux:
+  #   needs: setup
+  #   uses: ./.github/workflows/build-linux.yml
+  #   with:
+  #     version_id: ${{ needs.setup.outputs.version_id }}
+  #     today: ${{ needs.setup.outputs.today }}
+
+  build-windows:
     needs: setup
-    uses: ./.github/workflows/build-linux.yml
+    uses: ./.github/workflows/build-windows.yml
     with:
       version_id: ${{ needs.setup.outputs.version_id }}
       today: ${{ needs.setup.outputs.today }}
-
+      
   # Final job to collect artifacts and post to the release page
   publish:
-    needs: [setup, build-linux]
+    needs: [setup, build-windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'push'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
+      # The version_id and today will be passed to the LisaEm build script as env variables,
+      # so that they will appear in the LisaEm's Help->About menu.
       version_id: ${{ steps.vars.outputs.version_id }}
       today: ${{ steps.vars.outputs.today }}
       # The version in the file name will start with today's date for continuous builds, so that they will be ordered nicely chronologically in the release page
@@ -34,7 +36,7 @@ jobs:
             # A continuous build. Use the commit id. Example: version_id=continuous-3e51852
             VERSION_ID="continuous-${GITHUB_SHA::7}"
             echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
-            echo "version_in_file_name=$TODAY-$VERSION_ID" >> $GITHUB_OUTPUT
+            echo "version_in_file_name=continuous-$TODAY-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
   # Call the Child Workflows
@@ -44,6 +46,7 @@ jobs:
   #   with:
   #     version_id: ${{ needs.setup.outputs.version_id }}
   #     today: ${{ needs.setup.outputs.today }}
+  #     version_in_file_name: ${{ needs.setup.outputs.version_in_file_name }}
 
   build-windows:
     needs: setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,5 +83,8 @@ jobs:
             **/*.deb
             **/*.AppImage
             **/*.exe
-            **/*.dmg
             **/*.zip
+            **/*.dmg
+            **/*.pkg
+            **/*.app
+

--- a/bashbuild/Linux.sys
+++ b/bashbuild/Linux.sys
@@ -59,6 +59,29 @@ function windres() {
 true 
 }
 
+
+# Note by @TorZidan: 
+# Here is a typical content of the generated debian package:
+# dpkg --info pkg/LisaEm-1.2.7-RC4-2022.04.01-ubuntu-24.04-amd64.deb 
+#  new Debian package, version 2.0.
+#  size 3871750 bytes: control archive=357 bytes.
+#      325 bytes,     8 lines      control
+#  Package: LisaEm
+#  Version: 1.2.7-RC4-2022.04.01
+#  Architecture: amd64
+#  Maintainer: Ray Arachelian <jeremysalwen>
+#  Depends: gtk3, gdk-pixbuf2, libpangocairo, libgtk, libcario, libpangoft2, libpango1, libtiff, libglib
+#  Installed-Size: 10848
+#  Homepage: https://lisaem.sunder.net
+#  Description: The first fully functional Lisa Emulator™
+#
+# There are numberous problems here, which I (@TorZidan) have decided to leave as is:
+# - The package name "LisaEm" should be all-lowercase. But renaming it to "lisaem" may break existing installations.
+#   It is still doable, by adding 2 more fields:  Replaces: LisaEm (<< 1.2.7~rc4) , Breaks: LisaEm (<< 1.2.7~rc4)
+# - The version "1.2.7-RC4-2022.04.01" should be e.g. "1.2.7~rc4-2022.04.01", so that
+#   the release version "1.2.7-2022.04.01" will be newer (currently it is older) than this.
+# - The "Depends" field has incorrect, outdated values.
+# - The package files are being installed in "/usr/local/bin" and "/usr/local/share/", which is not standard, see them with "dpkg -c <filename>
 function makedebpkgcontrol() {
 size=$(du -sk "${XTLD}/pkg/build/tmp/${COMPANY}/${SOFTWARE}" | cut -f1)
 
@@ -68,7 +91,7 @@ machine="$(echo $MACHINE | sed -e 's/x86_64/amd64/g' )" # DEBs prefer amd64 in a
 # The debian package version must start with a digit
 # and the allowed characters are: digits, letters, .+-~:
 DEBVERSION="${VER}"
-if [[ -z "$VER" ]] || [[ "$VER" == "undefined" ]]; then
+if [[ -z "$VER" ]] || [[ "$VER" == "undefined" ]] || [[ "$VER" == "continuous-"* ]]; then
    DEBVERSION="0-${VER}"
 fi
 
@@ -94,8 +117,8 @@ function LinuxDebianPackage() {
   mkdir -pm755 build/tmp
   cd build/tmp || exit $?
 
-  # output package here
-  export DEBNAME="${XTLD}/pkg/${SOFTWARE}.deb"
+  # The generated Debian package file name. It will be further renamed when building it on Github Actions.
+  export DEBNAME="${XTLD}/pkg/${SOFTWARE}_amd64.deb"
 
   echo "  + $DEBNAME" 1>&2
 
@@ -118,17 +141,12 @@ function LinuxDebianPackage() {
   (cd "${XTLD}/pkg/build/tmp/${COMPANY}/${SOFTWARE}/" && tar cpf - .) | (cd "${DEBSTAGE}" && tar xpf -)
   #echo "to           $DEBSTAGE $(du -sh $DEBSTAGE)" 1>&2
 
-  if [[ -f /etc/os-release ]]; then
-     machine="$(echo $MACHINE | sed -e 's/x86_64/amd64/g' )" # DEBs prefer amd64 in architecture.
-     export DEBNAME="${SOFTWARE}-${OSREL_ID}-${OSREL_VERSION_ID}-${machine}.deb"
-  fi
-
   makedebpkgcontrol "$DEBSTAGE/DEBIAN"
 
   # build the package
   cd "${XTLD}/pkg/build/tmp/deb" || exit $?
 
-  dpkg-deb --build ${SOFTWARE} "${XTLD}/pkg/$DEBNAME" 2>&1 >"${XTLD}/pkg/${DEBNAME}.log" || exit $?
+  dpkg-deb --build ${SOFTWARE} "$DEBNAME" 2>&1 >"${DEBNAME}.log" || exit $?
 
   # create hashes
   if [[ -f "$DEBNAME" ]]; then

--- a/bashbuild/packages.fn
+++ b/bashbuild/packages.fn
@@ -67,8 +67,8 @@ function create_packages_for_os() {
           [[ -z "$MACHINE" ]] && export MACHINE="$( uname -m )" 
           PKGNAME="${XTLD}/pkg/LisaEm-win-${MACHINE}.zip"
           echo "Creating ZIP and/or NSIS (if available) Windows Package: $PKGNAME" 1>&2
-          cd "$PREFIX/../.." || exit 1
-          WinZIPPackage "$PKGNAME" "./${COMPANY}/${SOFTWARE}"
+          cd "$PREFIX/../../${COMPANY}" || exit 1
+          WinZIPPackage "$PKGNAME" "./${SOFTWARE}"
           WinNSISPackage
       fi
       elapsed=$(get_elapsed_time) && [[ -n "$elapsed" ]] && echo "$elapsed seconds" || echo

--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -317,10 +317,11 @@ int o_effective_lisa_vid_size_x = 720;
 void black(void);
 
 // The default configuration object for the application. 
-// On Linux, it is typically stored in file "~/lisaem.conf"
-// On Windows it is in the registry, under HKCU\Software\Vendor\Appname
+// On Linux, it is typically stored in file "~/.lisaem"
+// On Windows it is in the registry, under HKEY_CURRENT_USER\Software\lisaem
 // On MacOS it is ~/Library/Preferences/com.vendor.appname.plist.plist 
-wxConfigBase *myConfig;  // tt is being read at startup this way:  myConfig = wxConfig::Get();
+// It stores, among other things, the LisaEm config filename 
+wxConfigBase *myConfig;  // it is being read at startup this way:  myConfig = wxConfig::Get();
 wxString myconfigfile;   // the LisaEm config filename, e.g. "~/lisaem.conf"
 wxFileStream *pConfigIS; // config file
 

--- a/src/host/wxui/lisaem_wx.cpp
+++ b/src/host/wxui/lisaem_wx.cpp
@@ -316,8 +316,12 @@ int o_effective_lisa_vid_size_x = 720;
 
 void black(void);
 
-wxConfigBase *myConfig;  // default configuration (just a pointer to the active config)
-wxString myconfigfile;   // config filename
+// The default configuration object for the application. 
+// On Linux, it is typically stored in file "~/lisaem.conf"
+// On Windows it is in the registry, under HKCU\Software\Vendor\Appname
+// On MacOS it is ~/Library/Preferences/com.vendor.appname.plist.plist 
+wxConfigBase *myConfig;  // tt is being read at startup this way:  myConfig = wxConfig::Get();
+wxString myconfigfile;   // the LisaEm config filename, e.g. "~/lisaem.conf"
 wxFileStream *pConfigIS; // config file
 
 LisaConfigFrame *my_LisaConfigFrame = NULL;
@@ -3229,6 +3233,7 @@ bool LisaEmApp::OnInit()
 
     myConfig = wxConfig::Get(); // this one is the global configuration for the app.
                                 // get the path to the last opened Lisaconfig and load that.
+    // Read the LisaEm preferences file name from myConfig. If no such entry, then use the preference file name in defaultconfig.
     myconfigfile = myConfig->Read(_T("/lisaconfigfile"), defaultconfig);
 
     if (on_start_lisaconfig != "")
@@ -7397,8 +7402,12 @@ void LisaEmFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
     wxString description = _T("The first fully functional Apple Lisa emulator.");
     wxString exePath = wxStandardPaths::Get().GetExecutablePath();
     wxFileName exeFile(exePath);
-    description << "\n\nThe LisaEm binary is in : " << exeFile.GetFullPath();
-    description << "\n\nThe Skin resource folder is: "<< CSTR(skindir);
+    description << "\n\nThe LisaEm preferences file is: "<< myconfigfile;
+    description << "\n\nThe LisaEm binary is: " << exeFile.GetFullPath();
+    description << "\n\nThe Skin resource folder is: "<< skindir;
+
+
+    
 
 #ifdef BUILTBY
     description << "\n\n" BUILTBY;
@@ -7546,7 +7555,7 @@ void LisaEmFrame::OnOpen(wxCommandEvent& WXUNUSED(event))
     wxFileDialog open(this, wxT("Open LisaEm Preferences:"),
                       wxEmptyString,
                       wxEmptyString,
-                      wxT("LisaEm Preferences (*.lisaem)|*.lisaem|All (*.*)|*.*"),
+                      wxT("LisaEm Preferences (*.conf)|*.conf|All (*.*)|*.*"),
                       (long int)wxFD_OPEN, wxDefaultPosition);
 
     if (open.ShowModal() == wxID_OK)
@@ -7592,7 +7601,7 @@ void LisaEmFrame::OnSaveAs(wxCommandEvent& WXUNUSED(event))
     wxFileDialog open(this, wxT("Save LisaEm Preferences As:"),
                       justTheDir,      // path
                       justTheFilename, // prefs file name
-                      wxT("LisaEm Preferences (*.lisaem)|*.lisaem|All (*.*)|*.*"),
+                      wxT("LisaEm Preferences (*.conf)|*.conf|All (*.*)|*.*"),
                       (long int)wxFD_SAVE, wxDefaultPosition);
 
     if (open.ShowModal() == wxID_OK)

--- a/src/lisa/io_board/z8530-pty.c
+++ b/src/lisa/io_board/z8530-pty.c
@@ -64,15 +64,16 @@
 
 #ifndef __MSVCRT__
 
+// Somehow prevents compilation warnings.
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE 600
+#define __USE_BSD
+
 // Claude says O_NDELAY is equivalent to O_NONBLOCK on macOS systems
 // Create a compatibility shim
 #ifndef O_NDELAY
 #define O_NDELAY O_NONBLOCK
 #endif
-
-// Somehow prevents compilation warnings.
-#define _XOPEN_SOURCE 600
-#define __USE_BSD
 
 #include <vars.h>
 #include <z8530_structs.h>

--- a/src/lisa/io_board/z8530-shell.c
+++ b/src/lisa/io_board/z8530-shell.c
@@ -49,6 +49,11 @@
 
 #ifndef __MSVCRT__
 
+// Somehow prevents compilation warnings.
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE 600
+#define __USE_BSD
+
 #include <vars.h>
 #include <z8530_structs.h>
 #include <stdlib.h>
@@ -65,9 +70,6 @@
 #ifndef sun
 #include <err.h>
 #endif
-
-#define _XOPEN_SOURCE 600
-#define __USE_BSD
 
 #include <fcntl.h>
 #include <errno.h>

--- a/src/lisa/io_board/z8530-shell.c
+++ b/src/lisa/io_board/z8530-shell.c
@@ -54,6 +54,10 @@
 #define _XOPEN_SOURCE 600
 #define __USE_BSD
 
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <vars.h>
 #include <z8530_structs.h>
 #include <stdlib.h>
@@ -80,6 +84,12 @@
 #include <sys/ioctl.h>
 #include <string.h>
 #include <unistd.h>
+
+// Claude says O_NDELAY is equivalent to O_NONBLOCK on macOS systems
+// Create a compatibility shim
+#ifndef O_NDELAY
+#define O_NDELAY O_NONBLOCK
+#endif
 
 // two internal serial ports, 4 port serial card * 3 slots = 14 future if Uni+/Xenix
 // and Quad Port Cards are implemented, for now leave it at 2.


### PR DESCRIPTION
The Github Actions in the new file "release.yml" do two things:

- on every commit, it launches a "continuous build", which builds LisaEm packages for Linux, Windows and MacOS, and publishes them in the "continuous" Releases section. See example here: https://github.com/TorZidan/lisaem-fork/releases/tag/continuous

- on "create new release", it does the same, but also publishes these "build artifacts" under that given release, e.g. https://github.com/TorZidan/lisaem-fork/releases/tag/2.0.2 . It takes about 30 minutes to complete that.

When creating a new release (using the "Draft a new release" button under "Releases"), make sure to also create a new tag, and name the tag e.g. 2.0.1 (in format major.minor.revision). This way the newly generated .deb package will have a version that is greater (newer) than any currently installed LisaEm debian package, and the "dpkg" tool will install it (it refuses to install a debian package if it finds that it's older than the currently installed one).

In addition, the new tag name (e.g. "2.0.1") will appear in LisaEm's Help->About dailog, and in the generated artifact file names, along with today's date.

I tested running LisaEm from the generated files, and they work fine.

I recommend deleting the existing workflow.yaml file because the new continuous build does that (build LisaEm on Linux), and more.

The new "AppImage" Linux package is very easy to use: Just download the file, make it executable (chmld +x ...), and run it. No installation necessary .

Note that when I download the generated .zip file on Windows 11 and extract it and try to run LisaEm.exe, Windows complains that the file is not trusted; I can still run it, but the user experience is not ideal. I just found out that we could possibly overcome this: we can apply at [SignPath.org](https://signpath.org/apply). They provide free code signing for legitimate open-source projects.They sign our build artifacts remotely during the build process.  So I will look into that next.

We should add eventually one more action: build LisaEm on Arm Linux 32 and 64 bit, e.g. for RaspberryPi.

Hopefully these new builds will encourage more people to try LisaEm.
  
Enjoy!


